### PR TITLE
[UT] Fix unit test failure of gpu_tensorpool_allocator_test.

### DIFF
--- a/tensorflow/core/common_runtime/gpu_tensorpool_allocator_test.cc
+++ b/tensorflow/core/common_runtime/gpu_tensorpool_allocator_test.cc
@@ -297,7 +297,7 @@ TEST(GPUTensorPoolAllocatorTest, HugeMemoryAllocation) {
   for (int i = 0; i < 2000; ++i) {
     GPUScopedMemoryCollector c;
     std::vector<int> alignments = {64};
-    std::vector<int> sizes = {512*1024*1024, 64*1024*1024};
+    std::vector<int> sizes = {16*1024*1024, 8*1024*1024};
     std::vector<void*> vec;
     for (int i = 0; i < 2; ++i) {
       for (auto alignment : alignments) {


### PR DESCRIPTION
When parallel run multiple gpu unit-test, there's no enough
GPU memory for HugeMemoryAllocation in gpu_tensorpool_allocator_test.