### PR TITLE
[Embedding] Add CPU fused embedding ops.

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_FusedSafeEmbeddingLookupSparseLocal.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_FusedSafeEmbeddingLookupSparseLocal.pbtxt
@@ -1,0 +1,3 @@
+op {
+  graph_op_name: "FusedSafeEmbeddingLookupSparseLocal"
+}

--- a/tensorflow/core/api_def/base_api/api_def_FusedSafeEmbeddingLookupSparseLocalGrad.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_FusedSafeEmbeddingLookupSparseLocalGrad.pbtxt
@@ -1,0 +1,3 @@
+op {
+  graph_op_name: "FusedSafeEmbeddingLookupSparseLocalGrad"
+}

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -5291,13 +5291,82 @@ tf_cuda_library(
 
 tf_kernel_library(
     name = "fused_embedding_ops",
+    srcs = [
+        "fused_embedding/embedding_lookup_sparse_local_op.cc",
+        "fused_embedding/embedding_lookup_sparse_pre_op.cc",
+        "fused_embedding/embedding_lookup_sparse_post_op.cc",
+    ],
+    hdrs = ["fused_embedding/embedding_lookup_sparse_op.h"],
     gpu_srcs = [
         "fused_embedding/fused_embedding_local_ops_gpu.cu.cc",
         "fused_embedding/fused_embedding_pre_ops_gpus.cu.cc",
         "fused_embedding/fused_embedding_post_ops_gpus.cu.cc"
     ],
-    deps = ["//third_party/eigen3"] + DYNAMIC_DEPS +
+    deps = ["//third_party/eigen3"] + DYNAMIC_DEPS + mkl_deps() +
            if_cuda(["@cub_archive//:cub", ":fused_embedding_common_cuh"]),
+)
+
+tf_cc_test(
+    name = "embedding_lookup_sparse_pre_op_test",
+    size = "small",
+    srcs = ["fused_embedding/embedding_lookup_sparse_pre_op_test.cc"],
+    deps = [
+        ":fused_embedding_ops",
+        ":ops_testutil",
+        ":ops_util",
+        "//tensorflow/cc:cc_ops",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:framework_internal",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:tensorflow",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+    ],
+)
+
+tf_cc_test(
+    name = "embedding_lookup_sparse_post_op_test",
+    size = "small",
+    srcs = ["fused_embedding/embedding_lookup_sparse_post_op_test.cc"],
+    deps = [
+        ":fused_embedding_ops",
+        ":ops_testutil",
+        ":ops_util",
+        "//tensorflow/cc:cc_ops",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:framework_internal",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:tensorflow",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+    ],
+)
+
+tf_cc_test(
+    name = "embedding_lookup_sparse_post_grad_op_test",
+    size = "small",
+    srcs = ["fused_embedding/embedding_lookup_sparse_post_grad_op_test.cc"],
+    deps = [
+        ":fused_embedding_ops",
+        ":ops_testutil",
+        ":ops_util",
+        "//tensorflow/cc:cc_ops",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:framework_internal",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:tensorflow",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+    ],
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_local_op.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_local_op.cc
@@ -1,0 +1,737 @@
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/resource_mgr.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/resource_var.h"
+#include "tensorflow/core/framework/bounds_check.h"
+
+namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+namespace {
+    // input: input tensor value (it sores the id)
+    // cols: How many elements to do SparseSegmentSum
+    // output: rows * embedding_size
+    template<typename T>
+    static void sparse_gather_v1(T *input, int rows, int cols, 
+                                float *embedding_table, float *output,
+                                int embedding_size, bool is_mean) {
+    T *pidx = input;
+    for (int i = 0; i < rows; ++i) {
+        for (int j = 0; j < embedding_size; ++j) {
+        float value = 0;
+        int dense_num = 0;
+        for (int k = 0; k < cols; ++k) {
+            int embedding_row = (int)pidx[k];
+            if (embedding_row >= 0) {
+            value += embedding_table[embedding_row * embedding_size + j];
+            dense_num += 1;
+            }
+        }
+
+        if (is_mean && dense_num > 0) {
+            *output++ = value / dense_num;
+        } else {
+            *output++ = value;
+        }
+        }
+        pidx += cols;
+    }
+    }
+
+    // embedding_size = 1
+    template<typename T>
+    static void sparse_gather_embeddingsize1(T *input, int rows, int cols,
+                                            float *embedding_table, float *output,
+                                            bool is_mean) {
+    T *pidx = input;
+    for (int i = 0; i < rows; ++i) {
+        float value = 0;
+        int dense_num = 0;
+        for (int k = 0; k < cols; ++k) {
+        int embedding_row = pidx[k];
+        if (embedding_row >= 0) {
+            value += embedding_table[embedding_row];
+            dense_num += 1;
+        }
+        }
+        if (is_mean && dense_num > 0) {
+        *output++ = value / dense_num;
+        } else {
+        *output++ = value;
+        }
+        pidx += cols;
+    }
+    }
+
+    // input cols = 1
+    template<typename T>
+    static void sparse_gather_column1(T *input, int rows, float *embedding_table, 
+                            float *output, int embedding_size) {
+    T *pidx = input;
+    for (int i = 0; i < rows; ++i) {
+        int embedding_row = *pidx++;
+        if (embedding_row >= 0) {
+        float *pembedding = &embedding_table[embedding_row * embedding_size];
+        for (int j = 0; j < embedding_size; ++j) {
+            output[j] = pembedding[j];
+        }
+        } else {
+        for (int j = 0; j < embedding_size; ++j) {
+            output[j] = 0;
+        }
+        }
+        output += embedding_size;
+    }
+    }
+
+    template<typename T>
+    static void sparse_gather(T *input, int rows, int cols, float *embedding_table,
+                            float *output, int embedding_size, bool is_mean) {
+    if (embedding_size == 1) {
+        sparse_gather_embeddingsize1(input, rows, cols, embedding_table, output,
+                                    is_mean);
+    } else if (cols == 1) {
+        sparse_gather_column1(input, rows, embedding_table, output, embedding_size);
+    } else {
+        //printf("General sparse gather!\n");
+        sparse_gather_v1(input, rows, cols, embedding_table, output, embedding_size, 
+                        is_mean);
+    }
+    }
+
+    // Use memcpy or manually assign?
+    static void mycopy(float *dst, float *src, int float_num) {
+      memcpy(dst, src, float_num * sizeof(float));
+    }
+
+    static void myadd(float *dst, float *src, int float_num) {
+      for (int i = 0; i < float_num; ++i) {
+        dst[i] += src[i];
+      }
+    }
+
+
+    template<typename T>
+    static void row_add(std::map<T *, std::vector<T *>> &mapSet, int64 row_nums) {
+
+      for (auto it = mapSet.begin(); it != mapSet.end(); ++it){
+        T * dst = it->first;
+        std::vector<T *> srcs(std::move(it->second));
+        int64 src_size = srcs.size();
+
+        for (int row = 0; row < row_nums; ++row){
+          dst[row] = 0.0;
+          for (int index = 0; index < src_size; ++index) {
+            dst[row] += srcs[index][row];
+          }
+        }
+      }
+    }
+
+    template<typename T>
+    static void row_add_mean(std::map<T *, std::vector<T *>> &mapSet, int64 row_nums, bool is_mean) {
+
+#define L(n) srcs[index + n][row]
+
+      for (auto it = mapSet.begin(); it != mapSet.end(); ++it){
+        T * dst = it->first;
+        std::vector<T *> srcs(std::move(it->second));
+        int64 src_size = srcs.size();
+
+        if (src_size==1){
+          for (int row = 0; row < row_nums; ++row){
+            dst[row] = srcs[0][row];
+          }
+          continue;
+        }
+
+        float sum_tmp = 0.0;
+        int64 index = 0;
+        int64 r = (src_size) % 8;
+        int64 m = 1;
+        if (src_size < 10 && is_mean) m = src_size;
+
+        for (int row = 0; row < row_nums; ++row){
+          sum_tmp = 0.0;
+          index = 0;
+          dst[row] = 0.0;
+          switch (r) {
+            case 2: {
+              sum_tmp = (L(0) + L(1)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 3: {
+              sum_tmp = (L(0) + L(1) + L(2)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 4: {
+              sum_tmp = (L(0) + L(1) + L(2) + L(3)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 5: {
+              sum_tmp = (L(0) + L(1) + L(2) + L(3) + L(4)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 6: {
+              sum_tmp = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 7: {
+              sum_tmp = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 0: {
+              dst[row] = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6) + L(7)) / m;
+              index += 8;
+              break;
+            }
+            case 1: {
+              dst[row] = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6) + L(7) + L(8)) / m;
+              index += 8;
+              break;
+            }
+          }
+          for (index += r; index < src_size; index += 8) {
+            sum_tmp = L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6) + L(7);
+            dst[row] += sum_tmp;
+          }
+          if (src_size >= 10 && is_mean) dst[row] /= src_size;
+        }
+      }
+    }
+
+    static void myscale(float *dst, float factor, int float_num) {
+      for (int i = 0; i < float_num; ++i) {
+          dst[i] *= factor;
+      }
+    }
+
+    template<typename Tid, typename Tshape>
+    static void sparse_gather(Tid *input, int64 input_size, Tshape *indice,
+                            int indice_dim, Tshape *shape, int rows, int cols,
+                            float *embedding_table, float *output,
+                            int embedding_size, bool is_mean) {
+      // Record how many values in each row
+      int *row_values = new int[rows];
+      memset(row_values, 0, rows * sizeof(int));
+
+      std::map<float *, std::vector<float *>> mapSet;
+
+      for (int64 i = 0; i < input_size; ++i) {
+        Tid id = input[i];
+        if (i < input_size && input[i] < 0) { // Skip invalid id
+          continue;
+        }
+        auto row = indice[i * indice_dim];
+        // for (int k = 1; k < indice_dim - 1; ++k) {
+        //   row = row * shape[k] + indice[i * indice_dim + k];
+        // }
+        row_values[row] += 1;
+
+        auto index = row * embedding_size;
+        if (!mapSet.count(&output[index])){
+          std::vector<float *> srcs;
+          mapSet[&output[index]] = srcs;
+        }
+        mapSet[&output[index]].push_back(&embedding_table[id * embedding_size]);
+      }
+
+      // row_add(mapSet, embedding_size);
+      row_add_mean(mapSet, embedding_size, is_mean);
+
+      for (int i = 0; i < rows; ++i) {
+        if (row_values[i] == 0) {
+          memset(&output[i * embedding_size], 0, embedding_size * sizeof(float));
+        // } else if (is_mean && row_values[i] > 1) {
+        //   float factor = 1.0f / row_values[i];
+        //   myscale(&output[i * embedding_size], factor, embedding_size);
+        }
+      }
+      delete[] row_values;
+    }
+}
+
+/*
+  sample: [['green' 'red' 'blue' 'yellow' 'pink' 'blue' 'red' 'indigo']
+           ['' '' '' '' '' '' '' '']
+           ['' '' '' 'yellow' 'pink' 'blue' 'red' 'indigo']
+           ['' '' '' '' '' '' '' '']
+           ['green' '' '' '' '' '' '' '']]
+     =>   [[ True  True  True  True  True  True  True  True]
+           [False False False False False False False False]
+           [False False False  True  True  True  True  True]
+           [False False False False False False False False]
+           [ True False False False False False False False]]
+--------------------------------------------------------------------------------------
+  weight: float[[ 0.23860918  0.07992432 -0.7441818 ]
+                [-0.8256738  -0.50271106  0.39016065]
+                [-0.7978571   0.3993331  -0.12494776]
+                [-0.555991   -0.6705441  -0.23192379]
+                [-0.5283828   0.19715567  0.12184268]]
+  input: int64[4 0 0 1 1 0 0 1 1 1 0 0 1 4] from StringToHashBucketFast output
+  dense_shape: int64[5 8]
+  indice: int64[[0 0] from to_sparse_input/indices(Where) output
+                [0 1]
+                [0 2]
+                [0 3]
+                [0 4]
+                [0 5]
+                [0 6]
+                [0 7]
+                [2 3]
+                [2 4]
+                [2 5]
+                [2 6]
+                [2 7]
+                [4 0]]
+    embedded: float[[-0.25637093 -0.12391002 -0.21055032]
+                    [ 0.          0.          0.        ]
+                    [-0.3999606  -0.2696569  -0.06357633]
+                    [ 0.          0.          0.        ]
+                    [-0.5283828   0.19715567  0.12184268]]
+-----------------------------------------------------------------------------------
+      input_size: sum of input tensor size == 14
+      indice_dim: dim_size(1) of indice tensor[14, 2] == 2
+      shape: dense_shape == [5 8]
+      batch_size: dim of dense_shape == 5
+      cols: dim_size(1) of dense_shape == 8
+      embedding_size: dim_size(1) of weight tensor == 3
+      sparse_gather(input, input_size, indice, indice_dim, shape, batch_size,
+                    cols, weight, output, embedding_size, is_mean);
+*/
+
+template <typename Device, typename Tid, typename Tshape>
+class FusedSafeEmbeddingLookupSparseLocalOp : public OpKernel {
+public:
+  explicit FusedSafeEmbeddingLookupSparseLocalOp(OpKernelConstruction* context)
+           : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("combiner", &combiner_));
+    //OP_REQUIRES_OK(context, context->GetAttr("Dims", &dims));
+    node_name = context->def().name();
+  }
+
+  ~FusedSafeEmbeddingLookupSparseLocalOp() {}
+
+  void Compute(OpKernelContext* context) override {
+    // Grab the weight
+    float *weight;
+    const Tensor* weight_tensor = &context->input(0);
+
+    // for saved model
+    if (weight_tensor->dtype() == DT_RESOURCE) {
+      Var* variable;
+      OP_REQUIRES_OK(context,
+                     LookupResource(context, HandleFromInput(context, 0), 
+                                    &variable));
+      core::ScopedUnref s(variable);
+      weight_tensor = variable->tensor();
+      OP_REQUIRES(context, weight_tensor->dtype() == DT_FLOAT,
+                  errors::InvalidArgument("Expect float weight in ",
+                                          node_name));
+    }
+
+    weight = (float *)weight_tensor->tensor_data().data();
+    
+    // Input id
+    const Tensor& input_tensor = context->input(1);
+    Tid *input = (Tid *)input_tensor.tensor_data().data();
+    
+    const Tensor& shape_tensor = context->input(2);
+    Tshape *shape = (Tshape *)shape_tensor.tensor_data().data();
+
+    // To check the input
+    OP_REQUIRES(context, (shape_tensor.dims() == 1),
+                errors::InvalidArgument("Shape tensor is not valid (dims != 1)"));
+    OP_REQUIRES(context, (shape_tensor.dim_size(0) >= 2),
+                errors::InvalidArgument("Shape tensor is not valid (dim_size(0) < 2)"));
+
+    int64 input_size = 1;
+    for (int i = 0; i < input_tensor.dims(); ++i) {
+      input_size *= input_tensor.dim_size(i);
+    }
+    
+    int input_dims = shape_tensor.dim_size(0);
+    int cols = shape[input_dims - 1];
+    int batch_size = 1;
+    for (int i = 0; i < input_dims - 1; ++i) {
+      batch_size *= shape[i];
+    }
+    int embedding_size = weight_tensor->dim_size(1);
+    bool is_mean = (combiner_ == "mean");
+
+    const Tensor& indice_tensor = context->input(3);
+    Tshape *indice = (Tshape *)indice_tensor.tensor_data().data();
+    int indice_dim = indice_tensor.dim_size(1);
+
+    // Create an output tensor
+    Tensor* output_tensor = NULL;
+    TensorShape output_shape({batch_size, embedding_size});
+    OP_REQUIRES_OK(context, context->allocate_output(0, output_shape,
+                                                     &output_tensor));
+    float *output = (float *)output_tensor->tensor_data().data();
+
+    if (false && input_size == batch_size * cols) { // input id is dense
+      //fixme(marvin): disable this branch just for test.
+      sparse_gather(input, batch_size, cols, weight, output, embedding_size, is_mean);
+    } else { // input id is sparse
+      OP_REQUIRES(context, (indice_tensor.dims() == 2),
+                  errors::InvalidArgument("Indice tensor is not as expected (dims != 2)"));
+      OP_REQUIRES(context, (indice_tensor.dim_size(0) == input_size),
+                  errors::InvalidArgument("Indice tensor is not as expected (dim_size(0) != batch_size)"));
+      sparse_gather(input, input_size, indice, indice_dim, shape, batch_size,
+                    cols, weight, output, embedding_size, is_mean);
+    }
+  }
+
+private:
+  std::string combiner_;
+  std::string node_name;
+};
+
+REGISTER_KERNEL_BUILDER(                                        \
+    Name("FusedSafeEmbeddingLookupSparseLocal")                 \
+    .Device(DEVICE_CPU)                                         \
+    .TypeConstraint<int32>("T_id")                               \
+    .TypeConstraint<int64>("T_shape"),                           \
+    FusedSafeEmbeddingLookupSparseLocalOp<CPUDevice, int32, int64>);
+
+REGISTER_KERNEL_BUILDER(                                        \
+    Name("FusedSafeEmbeddingLookupSparseLocal")                 \
+    .Device(DEVICE_CPU)                                         \
+    .TypeConstraint<int64>("T_id")                               \
+    .TypeConstraint<int64>("T_shape"),                           \
+    FusedSafeEmbeddingLookupSparseLocalOp<CPUDevice, int64, int64>);
+
+
+enum class SparseSegmentReductionOperation { kSum, kMean, kSqrtN };
+
+namespace functor {
+
+template <typename T, typename Index, typename SegmentId>
+struct SparseSegmentGradFunctor {
+  void operator()(OpKernelContext* context,
+                  SparseSegmentReductionOperation operation,
+                  typename TTypes<T>::ConstMatrix input_flat,
+                  typename TTypes<Index>::ConstVec indices_vec,
+                  typename TTypes<SegmentId>::ConstVec segment_vec,
+                  typename TTypes<T>::Matrix output_flat) {
+    const int64_t N = indices_vec.size();
+    const SegmentId M = output_flat.dimension(0);
+
+    // Note that similar to SparseSegmentMean, we assume that segment_vec is
+    // already sorted and has non-negative values.
+    const SegmentId num_segments = input_flat.dimension(0);
+    const SegmentId last_segment_id_plus_one =
+        internal::SubtleMustCopy(segment_vec(N - 1)) + 1;
+    OP_REQUIRES(context, last_segment_id_plus_one <= num_segments,
+                errors::InvalidArgument("Invalid number of segments"));
+
+    // Compute scaling factors for input.
+    std::vector<double> scaling(
+        (operation == SparseSegmentReductionOperation::kSum ? 0 : num_segments),
+        0.0);
+    if (operation != SparseSegmentReductionOperation::kSum) {
+      for (int64_t i = 0; i < N; ++i) {
+        const SegmentId idx = internal::SubtleMustCopy(segment_vec(i));
+        OP_REQUIRES(
+            context, FastBoundsCheck(idx, num_segments),
+            errors::InvalidArgument("Segment id ", idx, " out of range [0, ",
+                                    num_segments, ")."));
+        scaling[idx] += 1;
+      }
+      for (size_t i = 0; i < scaling.size(); ++i) {
+        switch (operation) {
+          case SparseSegmentReductionOperation::kSum: {
+            OP_REQUIRES(
+                context, false,
+                errors::Internal(
+                    "Should not happen: sum inside SparseSegmentReductionOp "
+                    "scaling generation."));
+          }
+          case SparseSegmentReductionOperation::kMean: {
+            scaling[i] = 1.0 / std::max(scaling[i], 1.0);
+            break;
+          }
+          case SparseSegmentReductionOperation::kSqrtN: {
+            scaling[i] = 1.0 / sqrt(std::max(scaling[i], 1.0));
+            break;
+          }
+            // No default to get compiler warnings for missing cases.
+        }
+      }
+    }
+
+    output_flat.setZero();
+    std::vector<bool> is_modified(M, false);
+
+    for (int64_t i = 0; i < N; ++i) {
+      const Index output_idx = internal::SubtleMustCopy(indices_vec(i));
+      OP_REQUIRES(context, FastBoundsCheck(output_idx, M),
+                  errors::InvalidArgument("Index ", output_idx,
+                                          " out of range [0, ", M, ")."));
+
+      const SegmentId idx = internal::SubtleMustCopy(segment_vec(i));
+      OP_REQUIRES(
+          context, FastBoundsCheck(idx, num_segments),
+          errors::InvalidArgument("Segment id ", idx, " out of range [0, ",
+                                  num_segments, ")."));
+
+      const T scale = (operation == SparseSegmentReductionOperation::kSum
+                           ? static_cast<T>(1)
+                           : static_cast<T>(scaling[idx]));
+      if (is_modified[output_idx]) {
+        if (scale == 1.0) {
+          output_flat.template chip<0>(output_idx) +=
+              input_flat.template chip<0>(idx);
+        } else {
+          output_flat.template chip<0>(output_idx) +=
+              input_flat.template chip<0>(idx) * scale;
+        }
+      } else {
+        if (scale == 1.0) {
+          output_flat.template chip<0>(output_idx) =
+              input_flat.template chip<0>(idx);
+        } else {
+          output_flat.template chip<0>(output_idx) =
+              input_flat.template chip<0>(idx) * scale;
+        }
+      }
+      is_modified[output_idx] = true;
+    }
+  }
+};
+
+}  // namespace functor
+
+template <typename Device, typename T, typename Tinput, typename Tindices, typename Tdense_shape>
+class FusedSafeEmbeddingLookupSparseLocalGradOp : public OpKernel {
+public:
+  explicit FusedSafeEmbeddingLookupSparseLocalGradOp(OpKernelConstruction* context)
+           : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("combiner", &combiner_));
+    //OP_REQUIRES_OK(context, context->GetAttr("Dims", &dims));
+
+    if (combiner_ == "sum") {
+      operation_ = SparseSegmentReductionOperation::kSum;
+    } else if (combiner_ == "mean") {
+      operation_ = SparseSegmentReductionOperation::kMean;
+    } else if (combiner_ == "sqrtn") {
+      operation_ = SparseSegmentReductionOperation::kSqrtN;
+    } else {
+      OP_REQUIRES(context, false,
+          errors::InvalidArgument("Currently, 'mean', 'sqrtn' and 'sum' are only supported"));
+    }
+
+    node_name = context->def().name();
+
+    static bool printed = false;
+    if (!printed) {
+      printf("******** FusedSafeEmbeddingLookupSparseLocalGradOp ********\n");
+      printed = true;
+    }
+  }
+
+  ~FusedSafeEmbeddingLookupSparseLocalGradOp() {
+  }
+
+  void Compute(OpKernelContext* context) override {
+    // Grab gradients
+    const Tensor& gradients_tensor = context->input(0);
+    T *gradients = (T *)gradients_tensor.tensor_data().data();
+    OP_REQUIRES(context, (gradients_tensor.dims() == 2),
+                errors::InvalidArgument("Gradients tensor is not valid (dims != 2)"));
+    int64 gradients_row = gradients_tensor.dim_size(0);
+    int64 embedding_col = gradients_tensor.dim_size(1);
+
+    // Grad input hash value
+    const Tensor& input_tensor = context->input(1);
+    Tinput *input = (Tinput *)input_tensor.tensor_data().data();
+    int64 input_size = 1;
+    for (int i = 0; i < input_tensor.dims(); ++i) {
+      input_size *= input_tensor.dim_size(i);
+    }
+
+    // Grad indices value
+    const Tensor& indices_tensor = context->input(2);
+    Tindices *indices_ptr = (Tindices *)indices_tensor.tensor_data().data();
+    int indices_row = indices_tensor.dim_size(0);
+    int indices_col = indices_tensor.dim_size(1);
+    OP_REQUIRES(context, (indices_tensor.dims() == 2),
+                errors::InvalidArgument("Indice tensor is not as expected (dims != 2)"));
+    OP_REQUIRES(context, (indices_tensor.dim_size(0) == input_size),
+                errors::InvalidArgument("Indice tensor is not as expected (dim_size(0) != batch_size)"));
+    std::vector<Tindices> input_indices; // collect first col
+    for (int64 i = 0; i < indices_row; ++i) {
+      input_indices.emplace_back(indices_ptr[i*indices_col]);
+    }
+
+    // Grad input dense shape
+    const Tensor& dense_shape_tensor = context->input(3);
+    Tdense_shape *dense_shape = (Tdense_shape *)dense_shape_tensor.tensor_data().data();
+    OP_REQUIRES(context, (dense_shape_tensor.dims() == 1),
+                errors::InvalidArgument("Shape tensor is not valid (dims != 1)"));
+    OP_REQUIRES(context, (dense_shape_tensor.dim_size(0) >= 2),
+                errors::InvalidArgument("Shape tensor is not valid (dim_size(0) < 2)"));
+    int input_dims = dense_shape_tensor.dim_size(0);
+    int input_cols = dense_shape[input_dims - 1];
+    int batch_size = 1;
+    for (int i = 0; i < input_dims - 1; ++i) {
+      batch_size *= dense_shape[i];
+    }
+    OP_REQUIRES(context, (gradients_row == batch_size),
+                errors::InvalidArgument("gradients row is not same as batch_size)"));
+
+    // Grad combiner
+    // bool is_mean = (combiner == 1);
+
+    // compute unique value and indices of input hash value
+    std::vector<Tinput> unique_value;
+    std::vector<Tinput> unique_indices;
+    unique_value.reserve(input_size);
+    unique_indices.reserve(input_size);
+    for (int64 i = 0; i < input_size; ++i) {
+        Tinput id = input[i];
+        if (id < 0) { // Skip invalid id
+          continue;
+        }
+        auto it = std::find(unique_value.begin(), unique_value.end(), id);
+        if (it == unique_value.end()) { // no find
+          unique_indices.push_back(unique_value.size());
+          unique_value.push_back(id);
+        }
+        else {
+          unique_indices.push_back(it - unique_value.begin());
+        }
+    }
+
+    // printf("unique_indices: ");
+    // for (int i = 0; i < unique_indices.size(); ++i)
+    //   printf("%d ", unique_indices[i]);
+    // printf("\n");
+
+    // printf("input_indices: ");
+    // for (int i = 0; i < input_indices.size(); ++i)
+    //   printf("%d ", input_indices[i]);
+    // printf("\n");
+
+    // Create an output tensor
+    Tensor* output_tensor = NULL;
+    TensorShape output_shape({unique_value.size(), embedding_col});
+    OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output_tensor));
+    output_tensor->flat<T>().setZero();
+    T *output = (T *)output_tensor->tensor_data().data();
+    
+    memset(output, 0, embedding_col * sizeof(float) * unique_value.size());
+
+    Tensor* unique_tensor = NULL;
+    TensorShape unique_shape({unique_value.size()});
+    OP_REQUIRES_OK(context, context->allocate_output(1, unique_shape, &unique_tensor));
+    Tinput *unique = (Tinput *)unique_tensor->tensor_data().data();
+
+    int64 unique_num = unique_value.size();
+    for (int64 i = 0; i < unique_num; ++i) {
+      unique[i] = unique_value[i];
+    }
+
+    // if (input_size == batch_size * input_cols) { // input id is dense
+    // } else { // input id is sparse
+    // }
+
+    if (operation_ == SparseSegmentReductionOperation::kMean) {
+      auto input_flat = gradients_tensor.flat_outer_dims<T>();
+      typename TTypes<Tinput>::ConstVec indices_vec(unique_indices.data(), unique_indices.size());
+      typename TTypes<Tindices>::ConstVec segment_vec(input_indices.data(), input_indices.size());
+      auto output_flat = output_tensor->flat_outer_dims<T>();
+      functor::SparseSegmentGradFunctor<T, Tinput, Tindices>()(
+          context, operation_, input_flat, indices_vec, segment_vec, output_flat);
+    }
+    else if (operation_ == SparseSegmentReductionOperation::kSum) {
+      uint64 rows = unique_indices.size();
+      // std::vector<int64> row_values(unique_value.size(), 0);
+      std::map<float *, std::vector<float *>> mapSet;
+
+      for (int64 i = 0; i < rows; ++i) {
+        // row_values[unique_indices[i]] += 1;
+
+        auto index = unique_indices[i] * embedding_col;
+        // memset(&output[index * embedding_col], 0, embedding_col * sizeof(float));
+        if (!mapSet.count(&output[index])){
+          std::vector<float *> srcs;
+          mapSet[&output[index]] = srcs;
+        }
+        mapSet[&output[index]].push_back(&gradients[input_indices[i] * embedding_col]);
+
+      }
+
+      row_add(mapSet, embedding_col);
+      // printf("******Goto row_add_mean func.******\n");
+      // row_add_mean(mapSet, embedding_col, false);
+      
+      // for (int i = 0; i < unique_value.size(); ++i) {
+      //   if (row_values[i] == 0) {
+      //     memset(&output[i * embedding_col], 0, embedding_col * sizeof(float));
+      //   }
+      // }
+      // delete[] row_values;
+
+    }
+    else if (operation_ == SparseSegmentReductionOperation::kSqrtN) {
+
+    }
+  }
+
+private:
+  template <typename Tdata>
+  void copy(Tdata* dst, const Tdata* src, const int64 num) {
+    memcpy(dst, src, num * sizeof(T));
+  }
+
+  template <typename Tdata>
+  void add(Tdata* dst, const Tdata* src, const int64 num) {
+    for (int64 i = 0; i < num; ++i) {
+      dst[i] += src[i];
+    }
+  }
+
+  template <typename Tdata>
+  void scale(Tdata* dst, const Tdata factor, const int64 num) {
+    for (int64 i = 0; i < num; ++i) {
+      dst[i] *= factor;
+    }
+  }
+
+private:
+  std::string combiner_;
+  std::string node_name;
+  SparseSegmentReductionOperation operation_;
+};
+
+REGISTER_KERNEL_BUILDER(                            \
+    Name("FusedSafeEmbeddingLookupSparseLocalGrad") \
+    .Device(DEVICE_CPU)                             \
+    .TypeConstraint<float>("T")                     \
+    .TypeConstraint<int64>("Tinput")                \
+    .TypeConstraint<int32>("Tindices")              \
+    .TypeConstraint<int64>("Tdense_shape"),         \
+    FusedSafeEmbeddingLookupSparseLocalGradOp<CPUDevice, float, int64, int32, int64>);
+
+REGISTER_KERNEL_BUILDER(                            \
+    Name("FusedSafeEmbeddingLookupSparseLocalGrad") \
+    .Device(DEVICE_CPU)                             \
+    .TypeConstraint<float>("T")                     \
+    .TypeConstraint<int64>("Tinput")                \
+    .TypeConstraint<int64>("Tindices")              \
+    .TypeConstraint<int64>("Tdense_shape"),         \
+    FusedSafeEmbeddingLookupSparseLocalGradOp<CPUDevice, float, int64, int64, int64>);
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_local_op_test.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_local_op_test.cc
@@ -1,0 +1,885 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/cc/ops/const_op.h"
+#include "tensorflow/cc/ops/image_ops.h"
+#include "tensorflow/cc/ops/nn_ops.h"
+#include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/platform/test_benchmark.h"
+#include "tensorflow/core/public/session.h"
+
+namespace tensorflow {
+namespace {
+
+enum class Device { CPU, GPU };
+
+enum TestCase { Sqrtn, Mean, Sum, SqrtnAndMaxNorm200, MeanAndMaxNorm100 };
+
+template <TestCase test_case>
+void get_node_attr_from_test_case(string& combiner_str, float& max_norm) {
+  if (test_case == Sqrtn) {
+    combiner_str = "sqrtn";
+    max_norm = -1.0f;
+  } else if (test_case == Mean) {
+    combiner_str = "mean";
+    max_norm = -1.0f;
+  } else if (test_case == Sum) {
+    combiner_str = "sum";
+    max_norm = -1.0f;
+  } else if (test_case == SqrtnAndMaxNorm200) {
+    combiner_str = "sqrtn";
+    max_norm = 200.0f;
+  } else if (test_case == MeanAndMaxNorm100) {
+    combiner_str = "mean";
+    max_norm = 100.0f;
+  }
+}
+
+template <TestCase test_case>
+void fill_emb_vector_expected(Tensor* expected);
+
+template <>
+void fill_emb_vector_expected<Sqrtn>(Tensor* expected) {
+  test::FillValues<float>(
+      expected, {22.627416610717773, 24.0416316986084,   25.45584487915039,
+                 26.870058059692383, 28.284271240234375, 29.698484420776367,
+                 31.112699508666992, 32.526912689208984, 73.90083312988281,
+                 75.63288879394531,  77.36493682861328,  79.09698486328125,
+                 80.82904052734375,  82.56108856201172,  84.29314422607422,
+                 86.02519226074219,  124.70765686035156, 126.43971252441406,
+                 128.17176818847656, 129.90380859375,    131.6358642578125,
+                 133.367919921875,   135.09996032714844, 136.83201599121094,
+                 107.48023223876953, 108.89444732666016, 110.30866241455078,
+                 111.72286987304688, 113.1370849609375,  114.55130004882812,
+                 115.96551513671875, 117.37973022460938});
+}
+
+template <>
+void fill_emb_vector_expected<Mean>(Tensor* expected) {
+  test::FillValues<float>(
+      expected, {16.00000000000000, 17.00000000000000, 18.00000000000000,
+                 19.00000000000000, 20.00000000000000, 21.00000000000000,
+                 22.00000000000000, 23.00000000000000, 42.66666793823242,
+                 43.66666793823242, 44.66666793823242, 45.66666793823242,
+                 46.66666793823242, 47.66666793823242, 48.66666793823242,
+                 49.66666793823242, 72.00000000000000, 73.00000000000000,
+                 74.00000000000000, 75.00000000000000, 76.00000000000000,
+                 77.00000000000000, 78.00000000000000, 79.00000000000000,
+                 76.00000000000000, 77.00000000000000, 78.00000000000000,
+                 79.00000000000000, 80.00000000000000, 81.00000000000000,
+                 82.00000000000000, 83.00000000000000});
+}
+
+template <>
+void fill_emb_vector_expected<Sum>(Tensor* expected) {
+  test::FillValues<float>(
+      expected, {32.0,  34.0,  36.0,  38.0,  40.0,  42.0,  44.0,  46.0,
+                 128.0, 131.0, 134.0, 137.0, 140.0, 143.0, 146.0, 149.0,
+                 216.0, 219.0, 222.0, 225.0, 228.0, 231.0, 234.0, 237.0,
+                 152.0, 154.0, 156.0, 158.0, 160.0, 162.0, 164.0, 166.0});
+}
+
+template <>
+void fill_emb_vector_expected<SqrtnAndMaxNorm200>(Tensor* expected) {
+  test::FillValues<float>(
+      expected,
+      {22.62741661, 24.04163170, 25.45584488,  26.87005806,  28.28427124,
+       29.69848442, 31.11269951, 32.52691269,  73.90083313,  75.63288879,
+       77.36493683, 79.09698486, 80.82904053,  82.56108856,  84.29314423,
+       86.02519226, 92.61308289, 94.01081848,  95.40855408,  96.80628204,
+       98.20401764, 99.60175323, 100.99948120, 102.39721680, 71.20205688,
+       72.31395721, 73.42584991, 74.53774261,  75.64963531,  76.76153564,
+       77.87342834, 78.98532867});
+}
+
+class FusedEmbeddingLocalSparseLookUpOpTest : public OpsTestBase {
+ protected:
+  template <typename T, TestCase test_case>
+  void Run(Device device) {
+    if (device == Device::GPU) {
+      SetDevice(DEVICE_GPU,
+                std::unique_ptr<tensorflow::Device>(DeviceFactory::NewDevice(
+                    "GPU", {}, "/job:a/replica:0/task:0")));
+    }
+    DataType dtype = DataTypeToEnum<T>::value;
+    std::string combiner_str;
+    float max_norm;
+
+    get_node_attr_from_test_case<test_case>(combiner_str, max_norm);
+
+    TF_EXPECT_OK(NodeDefBuilder("fused_embedding_local_sparse_look_up",
+                                "FusedEmbeddingLocalSparseLookUp")
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(dtype))
+                     .Attr("T", dtype)
+                     .Attr("combiner", combiner_str)
+                     .Attr("max_norm", max_norm)
+                     .Finalize(node_def()));
+    TF_EXPECT_OK(InitOp());
+
+    const int nnz = 10;
+    const int batch_size = 4;
+    const int emb_vector_dim = 8;
+    const int entries = 8;
+    const int bucket_size = 16;
+
+    Tensor sp_values(DT_INT64, {nnz});
+    Tensor sp_indices(DT_INT64, {nnz, 2});
+    Tensor sp_dense_shape(DT_INT64, {2});
+    Tensor emb_variable(dtype, {bucket_size, emb_vector_dim});
+
+    test::FillValues<int64>(&sp_values, {3, 1, 4, 5, 7, 3, 12, 12, 15, 4});
+    test::FillValues<int64>(&sp_indices, {0, 1, 0, 5, 1, 2, 1, 1, 1, 7,
+                                          2, 1, 2, 4, 2, 7, 3, 0, 3, 6});
+    test::FillValues<int64>(&sp_dense_shape, {batch_size, entries});
+    test::FillValues<T>(
+        &emb_variable,
+        {0.0,   1.0,   2.0,   3.0,   4.0,   5.0,   6.0,   7.0,   8.0,   9.0,
+         10.0,  11.0,  12.0,  13.0,  14.0,  15.0,  16.0,  17.0,  18.0,  19.0,
+         20.0,  21.0,  22.0,  23.0,  24.0,  25.0,  26.0,  27.0,  28.0,  29.0,
+         30.0,  31.0,  32.0,  33.0,  34.0,  35.0,  36.0,  37.0,  38.0,  39.0,
+         40.0,  41.0,  42.0,  43.0,  44.0,  45.0,  46.0,  47.0,  48.0,  49.0,
+         50.0,  51.0,  52.0,  53.0,  54.0,  55.0,  56.0,  57.0,  58.0,  59.0,
+         60.0,  61.0,  62.0,  63.0,  64.0,  65.0,  66.0,  67.0,  68.0,  69.0,
+         70.0,  71.0,  72.0,  73.0,  74.0,  75.0,  76.0,  77.0,  78.0,  79.0,
+         80.0,  81.0,  82.0,  83.0,  84.0,  85.0,  86.0,  87.0,  88.0,  89.0,
+         90.0,  91.0,  92.0,  93.0,  94.0,  95.0,  96.0,  97.0,  98.0,  99.0,
+         100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0, 109.0,
+         110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0, 117.0, 118.0, 119.0,
+         120.0, 121.0, 122.0, 123.0, 124.0, 125.0, 126.0, 127.0});
+
+    AddInputFromArray<int64>(sp_values.shape(), sp_values.flat<int64>());
+    AddInputFromArray<int64>(sp_indices.shape(), sp_indices.flat<int64>());
+    AddInputFromArray<int64>(sp_dense_shape.shape(),
+                             sp_dense_shape.flat<int64>());
+    AddInputFromArray<T>(emb_variable.shape(), emb_variable.flat<T>());
+
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor emb_vector_expected(dtype, {batch_size, emb_vector_dim});
+    Tensor sp_values_offset_expected(DT_INT32, {batch_size});
+    fill_emb_vector_expected<test_case>(&emb_vector_expected);
+    test::FillValues<int32>(&sp_values_offset_expected, {0, 2, 5, 8});
+
+    const Tensor& emb_vector = *GetOutput(0);
+    const Tensor& values_offset = *GetOutput(1);
+    TF_EXPECT_OK(device_->Sync());
+
+    test::ExpectTensorNear<T>(emb_vector_expected, emb_vector, 1e-4);
+    test::ExpectTensorEqual<int32>(sp_values_offset_expected, values_offset);
+  }
+};
+
+template <TestCase test_case>
+void fill_grad_expected(Tensor* expected);
+
+template <>
+void fill_grad_expected<Sqrtn>(Tensor* expected) {
+  test::FillValues<float>(
+      expected, {0.000000000000000,  0.7071067690849304, 1.4142135381698608,
+                 2.1213204860687256, 2.8284270763397217, 3.535533905029297,
+                 4.242640972137451,  4.949747562408447,  0.000000000000000,
+                 0.7071067690849304, 1.4142135381698608, 2.1213204860687256,
+                 2.8284270763397217, 3.535533905029297,  4.242640972137451,
+                 4.949747562408447,  4.618802070617676,  5.196152687072754,
+                 5.773502826690674,  6.350852966308594,  6.928203582763672,
+                 7.505553722381592,  8.082903861999512,  8.66025447845459,
+                 4.618802070617676,  5.196152687072754,  5.773502826690674,
+                 6.350852966308594,  6.928203582763672,  7.505553722381592,
+                 8.082903861999512,  8.66025447845459,   4.618802070617676,
+                 5.196152687072754,  5.773502826690674,  6.350852966308594,
+                 6.928203582763672,  7.505553722381592,  8.082903861999512,
+                 8.66025447845459,   9.237604141235352,  9.81495475769043,
+                 10.392305374145508, 10.96965503692627,  11.547005653381348,
+                 12.124356269836426, 12.701705932617188, 13.279056549072266,
+                 9.237604141235352,  9.81495475769043,   10.392305374145508,
+                 10.96965503692627,  11.547005653381348, 12.124356269836426,
+                 12.701705932617188, 13.279056549072266, 9.237604141235352,
+                 9.81495475769043,   10.392305374145508, 10.96965503692627,
+                 11.547005653381348, 12.124356269836426, 12.701705932617188,
+                 13.279056549072266, 16.970563888549805, 17.677669525146484,
+                 18.384777069091797, 19.091882705688477, 19.79899024963379,
+                 20.5060977935791,   21.21320343017578,  21.920310974121094,
+                 16.970563888549805, 17.677669525146484, 18.384777069091797,
+                 19.091882705688477, 19.79899024963379,  20.5060977935791,
+                 21.21320343017578,  21.920310974121094});
+}
+
+template <>
+void fill_grad_expected<Mean>(Tensor* expected) {
+  test::FillValues<float>(
+      expected, {0.000000000000000,  0.500000000000000,  1.000000000000000,
+                 1.500000000000000,  2.000000000000000,  2.500000000000000,
+                 3.000000000000000,  3.500000000000000,  0.000000000000000,
+                 0.500000000000000,  1.000000000000000,  1.500000000000000,
+                 2.000000000000000,  2.500000000000000,  3.000000000000000,
+                 3.500000000000000,  2.6666667461395264, 3.000000000000000,
+                 3.3333332538604736, 3.6666667461395264, 4.000000000000000,
+                 4.333333492279053,  4.666666507720947,  5.000000000000000,
+                 2.6666667461395264, 3.000000000000000,  3.3333332538604736,
+                 3.6666667461395264, 4.000000000000000,  4.333333492279053,
+                 4.666666507720947,  5.000000000000000,  2.6666667461395264,
+                 3.000000000000000,  3.3333332538604736, 3.6666667461395264,
+                 4.000000000000000,  4.333333492279053,  4.666666507720947,
+                 5.000000000000000,  5.333333492279053,  5.666666507720947,
+                 6.000000000000000,  6.333333492279053,  6.666666507720947,
+                 7.000000000000000,  7.333333492279053,  7.666666507720947,
+                 5.333333492279053,  5.666666507720947,  6.000000000000000,
+                 6.333333492279053,  6.666666507720947,  7.000000000000000,
+                 7.333333492279053,  7.666666507720947,  5.333333492279053,
+                 5.666666507720947,  6.000000000000000,  6.333333492279053,
+                 6.666666507720947,  7.000000000000000,  7.333333492279053,
+                 7.666666507720947,  12.000000000000000, 12.500000000000000,
+                 13.000000000000000, 13.500000000000000, 14.000000000000000,
+                 14.500000000000000, 15.000000000000000, 15.500000000000000,
+                 12.000000000000000, 12.500000000000000, 13.000000000000000,
+                 13.500000000000000, 14.000000000000000, 14.500000000000000,
+                 15.000000000000000, 15.500000000000000});
+}
+
+template <>
+void fill_grad_expected<Sum>(Tensor* expected) {
+  test::FillValues<float>(
+      expected,
+      {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  0.0,  1.0,  2.0,  3.0,
+       4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+       8.0,  9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 8.0,  9.0,  10.0, 11.0,
+       12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0,
+       16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 16.0, 17.0, 18.0, 19.0,
+       20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0,
+       24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0});
+}
+
+template <>
+void fill_grad_expected<MeanAndMaxNorm100>(Tensor* expected) {
+  test::FillValues<float>(
+      expected,
+      {0.00000000,  0.50000000,  1.00000000,  1.50000000,  2.00000000, 2.50000000,  3.00000000, 3.50000000,
+       0.00000000,  0.50000000, 1.00000000,  1.50000000,  2.00000000,  2.50000000,  3.00000000, 3.50000000,
+       2.65028572,  2.98157120,  3.31285667,  3.64414287, 3.97542834,  4.30671406,  4.63799953,  4.96928549,
+       2.16437674, 2.43492365,  2.70547056,  2.97601795,  3.24656487,  3.51711202, 3.78765893,  4.05820608,
+       1.58337951,  1.78130186,  1.97922409, 2.17714667,  2.37506914,  2.57299161,  2.77091384,  2.96883631,
+       5.33333349,  5.66666651,  6.00000000,  6.33333349,  6.66666651, 7.00000000,  7.33333349,  7.66666651,
+       1.89459133,  2.01300311, 2.13141513,  2.24982715,  2.36823893,  2.48665094,  2.60506320,  2.72347474,
+       1.89459133,  2.01300311,  2.13141513,  2.24982715, 2.36823893,  2.48665094,  2.60506320,  2.72347474,
+       3.43474555, 3.57786012,  3.72097445,  3.86408877,  4.00720310,  4.15031767, 4.29343224,  4.43654633,
+       11.92628479, 12.42321396, 12.92014217, 13.41707039, 13.91399956, 14.41092777, 14.90785599, 15.40478516});
+}
+
+class FusedEmbeddingLocalSparseLookUpGradOpTest : public OpsTestBase {
+ protected:
+  template <typename T, TestCase test_case>
+  void Run(Device device) {
+    if (device == Device::GPU) {
+      SetDevice(DEVICE_GPU,
+                std::unique_ptr<tensorflow::Device>(DeviceFactory::NewDevice(
+                    "GPU", {}, "/job:a/replica:0/task:0")));
+    }
+    DataType dtype = DataTypeToEnum<T>::value;
+    std::string combiner_str;
+    float max_norm;
+    get_node_attr_from_test_case<test_case>(combiner_str, max_norm);
+
+    TF_EXPECT_OK(NodeDefBuilder("fused_embedding_local_sparse_look_up_grad",
+                                "FusedEmbeddingLocalSparseLookUpGrad")
+                     .Input(FakeInput(dtype))
+                     .Input(FakeInput(dtype))
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(DT_INT32))
+                     .Attr("T", dtype)
+                     .Attr("combiner", combiner_str)
+                     .Attr("max_norm", max_norm)
+                     .Finalize(node_def()));
+    TF_EXPECT_OK(InitOp());
+
+    const int nnz = 10;
+    const int batch_size = 4;
+    const int emb_vector_dim = 8;
+    const int bucket_size = 16;
+
+    Tensor top_grad(dtype, {batch_size, emb_vector_dim});
+    Tensor emb_variable(dtype, {bucket_size, emb_vector_dim});
+    Tensor sp_values(DT_INT64, {nnz});
+    Tensor sp_values_offset(DT_INT32, {batch_size});
+
+    test::FillValues<T>(
+        &top_grad,
+        {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0,
+         11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0,
+         22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0});
+    test::FillValues<T>(
+        &emb_variable,
+        {0.0,   1.0,   2.0,   3.0,   4.0,   5.0,   6.0,   7.0,   8.0,   9.0,
+         10.0,  11.0,  12.0,  13.0,  14.0,  15.0,  16.0,  17.0,  18.0,  19.0,
+         20.0,  21.0,  22.0,  23.0,  24.0,  25.0,  26.0,  27.0,  28.0,  29.0,
+         30.0,  31.0,  32.0,  33.0,  34.0,  35.0,  36.0,  37.0,  38.0,  39.0,
+         40.0,  41.0,  42.0,  43.0,  44.0,  45.0,  46.0,  47.0,  48.0,  49.0,
+         50.0,  51.0,  52.0,  53.0,  54.0,  55.0,  56.0,  57.0,  58.0,  59.0,
+         60.0,  61.0,  62.0,  63.0,  64.0,  65.0,  66.0,  67.0,  68.0,  69.0,
+         70.0,  71.0,  72.0,  73.0,  74.0,  75.0,  76.0,  77.0,  78.0,  79.0,
+         80.0,  81.0,  82.0,  83.0,  84.0,  85.0,  86.0,  87.0,  88.0,  89.0,
+         90.0,  91.0,  92.0,  93.0,  94.0,  95.0,  96.0,  97.0,  98.0,  99.0,
+         100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0, 109.0,
+         110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0, 117.0, 118.0, 119.0,
+         120.0, 121.0, 122.0, 123.0, 124.0, 125.0, 126.0, 127.0});
+    test::FillValues<int64>(&sp_values, {3, 1, 4, 5, 7, 3, 12, 12, 15, 4});
+    test::FillValues<int32>(&sp_values_offset, {0, 2, 5, 8});
+
+    AddInputFromArray<T>(top_grad.shape(), top_grad.flat<T>());
+    AddInputFromArray<T>(emb_variable.shape(), emb_variable.flat<T>());
+    AddInputFromArray<int64>(sp_values.shape(), sp_values.flat<int64>());
+    AddInputFromArray<int32>(sp_values_offset.shape(),
+                             sp_values_offset.flat<int32>());
+
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor grad_expected(dtype, {nnz, emb_vector_dim});
+    fill_grad_expected<test_case>(&grad_expected);
+
+    const Tensor& grad = *GetOutput(0);
+    TF_EXPECT_OK(device_->Sync());
+
+    test::ExpectTensorNear<T>(grad_expected, grad, 1e-4);
+  }
+};
+
+TEST_F(FusedEmbeddingLocalSparseLookUpOpTest, LocalFloatSumCpu) {
+
+  TF_EXPECT_OK(NodeDefBuilder("FusedSafeEmbeddingLookupSparseLocal",
+                              "FusedSafeEmbeddingLookupSparseLocal")
+                    .Input(FakeInput(DT_FLOAT))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Attr("T", DT_FLOAT)
+                    .Attr("combiner", "sum")
+                    .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  const int nnz = 10;
+  const int batch_size = 4;
+  const int emb_vector_dim = 8;
+  const int entries = 8;
+  const int bucket_size = 16;
+
+  Tensor sp_values(DT_INT64, {nnz});
+  Tensor sp_weight(DT_INT64, {nnz});
+  Tensor sp_indices(DT_INT64, {nnz, 2});
+  Tensor sp_dense_shape(DT_INT64, {2});
+  Tensor emb_variable(DT_FLOAT, {bucket_size, emb_vector_dim});
+
+  // [3, 1, 4, 5, 7, 3, 12, 12, 15, 4]
+  test::FillValues<int64>(&sp_values, {3, 1, 4, 5, 7, 3, 12, 12, 15, 4});
+  test::FillValues<int64>(&sp_weight, {3, 1, 4, 5, 7, 3, 12, 12, 15, 4});
+  // [0, 0, 1, 1, 1, 2, 2, 2, 3, 3]
+  test::FillValues<int64>(&sp_indices, {0, 1, 0, 5, 1, 2, 1, 1, 1, 7,
+                                        2, 1, 2, 4, 2, 7, 3, 0, 3, 6});
+  test::FillValues<int64>(&sp_dense_shape, {batch_size, entries});
+  test::FillValues<float>(
+      &emb_variable,
+      {0.0,   1.0,    2.0,   3.0,   4.0,   5.0,   6.0,   7.0,
+       8.0,   9.0,   10.0,  11.0,  12.0,  13.0,  14.0,  15.0,
+       16.0,  17.0,  18.0,  19.0,  20.0,  21.0,  22.0,  23.0,
+       24.0,  25.0,  26.0,  27.0,  28.0,  29.0,  30.0,  31.0,
+       32.0,  33.0,  34.0,  35.0,  36.0,  37.0,  38.0,  39.0,
+       40.0,  41.0,  42.0,  43.0,  44.0,  45.0,  46.0,  47.0,
+       48.0,  49.0,  50.0,  51.0,  52.0,  53.0,  54.0,  55.0,
+       56.0,  57.0,  58.0,  59.0,  60.0,  61.0,  62.0,  63.0,
+       64.0,  65.0,  66.0,  67.0,  68.0,  69.0,  70.0,  71.0,
+       72.0,  73.0,  74.0,  75.0,  76.0,  77.0,  78.0,  79.0,
+       80.0,  81.0,  82.0,  83.0,  84.0,  85.0,  86.0,  87.0,
+       88.0,  89.0,  90.0,  91.0,  92.0,  93.0,  94.0,  95.0,
+       96.0,  97.0,  98.0,  99.0, 100.0, 101.0, 102.0, 103.0,
+       104.0,105.0, 106.0, 107.0, 108.0, 109.0, 110.0, 111.0,
+       112.0,113.0, 114.0, 115.0, 116.0, 117.0, 118.0, 119.0,
+       120.0,121.0, 122.0, 123.0, 124.0, 125.0, 126.0, 127.0});
+
+  AddInputFromArray<float>(emb_variable.shape(), emb_variable.flat<float>());
+  AddInputFromArray<int64>(sp_values.shape(), sp_values.flat<int64>());
+  AddInputFromArray<int64>(sp_dense_shape.shape(),
+                            sp_dense_shape.flat<int64>());
+  AddInputFromArray<int64>(sp_indices.shape(), sp_indices.flat<int64>());
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor emb_vector_expected(DT_FLOAT, {batch_size, emb_vector_dim});
+  // Tensor sp_values_offset_expected(DT_INT32, {batch_size});
+  fill_emb_vector_expected<Sum>(&emb_vector_expected);
+  // test::FillValues<int32>(&sp_values_offset_expected, {0, 2, 5, 8});
+
+  const Tensor& emb_vector = *GetOutput(0);
+  // const Tensor& values_offset = *GetOutput(1);
+  // TF_EXPECT_OK(device_->Sync());
+
+  float *output = (float *)emb_vector.tensor_data().data();
+  float *output_ex = (float *)emb_vector_expected.tensor_data().data();
+
+  test::ExpectTensorNear<float>(emb_vector_expected, emb_vector, 1e-2);
+  // test::ExpectTensorEqual<int32>(sp_values_offset_expected, values_offset);
+}
+
+TEST_F(FusedEmbeddingLocalSparseLookUpOpTest, LocalGradFloatSumCpu) {
+
+  TF_EXPECT_OK(NodeDefBuilder("FusedSafeEmbeddingLookupSparseLocalGrad",
+                              "FusedSafeEmbeddingLookupSparseLocalGrad")
+                    .Input(FakeInput(DT_FLOAT)) // gradients
+                    .Input(FakeInput(DT_INT64)) // input hash value
+                    .Input(FakeInput(DT_INT64)) // dense_shape
+                    .Input(FakeInput(DT_INT64)) // indices
+                    .Attr("T", DT_FLOAT)
+                    .Attr("Tinput", DT_INT64)
+                    .Attr("Tindices", DT_INT64)
+                    .Attr("Tdense_shape", DT_INT64)
+                    .Attr("combiner", "sum")
+                    .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  const int nnz = 32;
+  const int batch_size = 32;
+  const int emb_vector_dim = 4;
+  const int entries = 1;
+  const int bucket_size = 16;
+
+  Tensor sp_values(DT_INT64, {nnz});
+  Tensor sp_indices(DT_INT64, {nnz, 2});
+  Tensor sp_dense_shape(DT_INT64, {2});
+  Tensor grad_variable(DT_FLOAT, {batch_size, emb_vector_dim});
+
+  test::FillValues<float>(
+      &grad_variable,
+      {-0.00363823911, 0.0138593055, 0.00232614437, 0.00241222954,
+       -0.000268990319, -0.00410466315, 0.00478722388, -0.000196215493,
+       -0.0044340631, -0.00725936424, -0.00691315765, -0.00612797868,
+       -0.00678675482, -0.00246100035, 0.00216219737, -0.00346030248,
+       0.00100048154, -0.00852716807, 0.00803291425, -0.000800206966,
+       -3.03583856e-05, 0.00524863973, -0.0163001865, -0.0109826243,
+       0.0830041766, 0.153927863, -0.0508279465, -0.00474824524,
+       7.8225421e-05, -0.000293536956, 0.00610643439, -0.00019871055,
+       -0.000780000235, -0.00221115421, 0.00387162319, 0.00222597015,
+       -0.0102384416, -0.00801581, -0.0017716008, 0.00598057127,
+       -0.00808391348, -0.00166459556, 0.00106997311, -0.00185864791,
+       0.00491535058, -0.00633693347, 0.0212651137, 0.00704831816,
+       -0.00338345463, -0.00668374076, -0.0000871402444, -0.000196078254,
+       0.00254824688, -0.00249796058, -0.0034719836, -0.003478111,
+       6.03029093e-06, -0.00211180653, 0.000114592229, -0.00240143575,
+       -0.00592383416, -0.00984606426, 0.00129341101, 0.00100650277,
+       0.000906444562, -0.00139640097, -0.000192714069, 0.00277191238,
+       -0.000245573436, -0.00680374401, 0.00356984767, -0.00120577728,
+       -0.000766036392, -0.00487764599, 0.000532136182, -0.00413817167,
+       -0.0302855149, -0.0406391025, 0.0006130244, 0.0183675159,
+       -0.00247384049, -0.00609699031, 0.00127684267, -0.00235637,
+       0.00715987338, 0.00783564895, -0.00139878597, -0.0048744888,
+       0.00356917572, -0.0164020304, 0.0179400034, 0.000975746894,
+       -0.00529623777, -0.00490315, 0.00691250199, 0.00286021968,
+       -0.00426661829, -0.00417789398, -0.00597105641, -0.00605484238,
+       0.00197085389, -0.00757023226, 0.00458694575, 0.00153650146,
+       -0.00345475, -0.00823391136, 0.000807857723, 0.0121598523,
+       -0.00745406374, -0.0135948248, 0.004774753, -0.00390140619,
+       -0.00208005216, -0.00362896058, 0.00558064319, -0.000532045437,
+       -0.00854093302, 0.00566324079, -0.00435794424, 0.00403016619,
+       0.000468764076, 0.000297251798, -0.00617758604, -0.00338481856,
+       0.00280403625, -0.00649327, -0.000154057736, -0.000479023496});
+  test::FillValues<int64>(&sp_values, {9, 2, 9, 2, 2, 9, 2, 2, 2, 2, 2, 2, 9, 2, 2, 2, 9, 2, 2, 2, 2, 9, 2, 9, 2, 2, 2, 9, 2, 9, 2, 2});
+  test::FillValues<int64>(&sp_indices, {0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10, 0, 11, 0, 12, 0, 13, 0, 14, 0, 15, 0, 16, 0, 17, 0, 18, 0, 19, 0, 20, 0, 21, 0, 22, 0, 23, 0, 24, 0, 25, 0, 26, 0, 27, 0, 28, 0, 29, 0, 30, 0, 31, 0});
+  test::FillValues<int64>(&sp_dense_shape, {batch_size, entries});
+
+  AddInputFromArray<float>(grad_variable.shape(), grad_variable.flat<float>());
+  AddInputFromArray<int64>(sp_values.shape(), sp_values.flat<int64>());
+  AddInputFromArray<int64>(sp_indices.shape(), sp_indices.flat<int64>());
+  AddInputFromArray<int64>(sp_dense_shape.shape(), sp_dense_shape.flat<int64>());
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor output1_tensor_expected(DT_FLOAT, {2, emb_vector_dim});
+  Tensor output2_tensor_expected(DT_INT64, {2});
+
+  test::FillValues<float>(&output1_tensor_expected,
+      {-0.0247110315, -0.00123064546, -0.0152365314, -0.0140080471,
+       0.0247110203, 0.00123063289, 0.0152365509, 0.0140080536});
+
+  test::FillValues<int64>(&output2_tensor_expected, {9, 2});
+  float *output1_ex = (float *)output1_tensor_expected.tensor_data().data();
+  int64 *output2_ex = (int64 *)output2_tensor_expected.tensor_data().data();
+
+  const Tensor& output1_tensor = *GetOutput(0);
+  const Tensor& output2_tensor = *GetOutput(1);
+
+  float *output1 = (float *)output1_tensor.tensor_data().data();
+  int64 *output2 = (int64 *)output2_tensor.tensor_data().data();
+
+  printf("out = %.11f , expect = %.11f\n", output1[5], output1_ex[5]);
+  printf("out = %.11f , expect = %.11f\n", output1[7], output1_ex[7]);
+  test::ExpectTensorNear<float>(output1_tensor_expected, output1_tensor, 1e-8);
+  test::ExpectTensorEqual<int64>(output2_tensor_expected, output2_tensor);
+}
+
+TEST_F(FusedEmbeddingLocalSparseLookUpOpTest, LocalGradFloatMeanCpu) {
+
+  TF_EXPECT_OK(NodeDefBuilder("FusedSafeEmbeddingLookupSparseLocalGrad",
+                              "FusedSafeEmbeddingLookupSparseLocalGrad")
+                    .Input(FakeInput(DT_FLOAT)) // gradients
+                    .Input(FakeInput(DT_INT64)) // input hash value
+                    .Input(FakeInput(DT_INT64)) // dense_shape
+                    .Input(FakeInput(DT_INT64)) // indices
+                    .Attr("T", DT_FLOAT)
+                    .Attr("Tinput", DT_INT64)
+                    .Attr("Tindices", DT_INT64)
+                    .Attr("Tdense_shape", DT_INT64)
+                    .Attr("combiner", "mean")
+                    .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  const int nnz = 9;
+  const int batch_size = 5;
+  const int emb_vector_dim = 4;
+  const int entries = 8;
+  const int bucket_size = 16;
+
+  Tensor sp_values(DT_INT64, {nnz});
+  Tensor sp_indices(DT_INT64, {nnz, 2});
+  Tensor sp_dense_shape(DT_INT64, {2});
+  Tensor grad_variable(DT_FLOAT, {batch_size, emb_vector_dim});
+
+  test::FillValues<float>(
+      &grad_variable,
+      {0.0103125420, 0.018807490, -0.0106398590, -0.029409127,
+       0.0054132286, 0.013920069, -0.0190976150, -0.023196392,
+       0.0100601720, 0.015330995, -0.0055795530, -0.024889620,
+       0.0108455080, 0.018832123, -0.0095151365, -0.029357582,
+       0.0100478110, 0.018798435, -0.0112019650, -0.029439624});
+  test::FillValues<int64>(&sp_values, {1, 1, 0, 4, 1, 1, 1, 0, 1});
+  test::FillValues<int64>(&sp_indices, {0, 1, 0, 3, 0, 6, 1, 3, 1, 6,
+                                        3, 3, 3, 4, 4, 1, 4, 7});
+  test::FillValues<int64>(&sp_dense_shape, {batch_size, entries});
+
+  AddInputFromArray<float>(grad_variable.shape(), grad_variable.flat<float>());
+  AddInputFromArray<int64>(sp_values.shape(), sp_values.flat<int64>());
+  AddInputFromArray<int64>(sp_indices.shape(), sp_indices.flat<int64>());
+  AddInputFromArray<int64>(sp_dense_shape.shape(), sp_dense_shape.flat<int64>());
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor output1_tensor_expected(DT_FLOAT, {3, emb_vector_dim});
+  Tensor output2_tensor_expected(DT_INT64, {3});
+  test::FillValues<float>(&output1_tensor_expected,
+      {0.0254510570, 0.0477297000, -0.0317581670, -0.075281680,
+       0.0084614195, 0.0156683810, -0.0091476020, -0.024522856,
+       0.0027066143, 0.0069600344, -0.0095488075, -0.011598196});
+  test::FillValues<int64>(&output2_tensor_expected, {1, 0, 4});
+  float *output1_ex = (float *)output1_tensor_expected.tensor_data().data();
+  int64 *output2_ex = (int64 *)output2_tensor_expected.tensor_data().data();
+
+  const Tensor& output1_tensor = *GetOutput(0);
+  const Tensor& output2_tensor = *GetOutput(1);
+
+  float *output1 = (float *)output1_tensor.tensor_data().data();
+  int64 *output2 = (int64 *)output2_tensor.tensor_data().data();
+
+  // printf("out = %f , expect = %f\n", output1[0], output1_ex[0]);
+  // printf("out = %f , expect = %f\n", output1[1], output1_ex[1]);
+  // printf("out = %f , expect = %f\n", output1[2], output1_ex[2]);
+  // printf("out = %f , expect = %f\n", output1[3], output1_ex[3]);
+
+  // printf("out = %d , expect = %d\n", output2[0], output2_ex[0]);
+  // printf("out = %d , expect = %d\n", output2[1], output2_ex[1]);
+  // printf("out = %d , expect = %d\n", output2[2], output2_ex[2]);
+
+  test::ExpectTensorNear<float>(output1_tensor_expected, output1_tensor, 1e-8);
+  test::ExpectTensorEqual<int64>(output2_tensor_expected, output2_tensor);
+}
+
+TEST_F(FusedEmbeddingLocalSparseLookUpOpTest, FloatSumCpu) {
+
+  TF_EXPECT_OK(NodeDefBuilder("FusedSafeEmbeddingLookupSparse",
+                              "FusedSafeEmbeddingLookupSparse")
+                    .Input(FakeInput(DT_FLOAT))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Attr("T", DT_FLOAT)
+                    .Attr("combiner", "sum")
+                    .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  const int nnz = 9;
+  const int batch_size = 5;
+  const int emb_vector_dim = 4;
+  const int entries = 8;
+  const int gathered_weight_size = 3;
+
+  Tensor sp_values(DT_INT64, {nnz});
+  Tensor sp_weight(DT_INT64, {nnz});
+  Tensor sp_indices(DT_INT64, {nnz, 2});
+  Tensor sp_dense_shape(DT_INT64, {2});
+  Tensor emb_variable(DT_FLOAT, {gathered_weight_size, emb_vector_dim});
+
+  // [1 1 0 4 1 1 1 0 1] -> [1 0 4], [0 0 1 2 0 0 0 1 0]
+  test::FillValues<int64>(&sp_values, {0, 0, 1, 2, 0, 0, 0, 1, 0});
+  test::FillValues<int64>(&sp_weight, {0, 0, 1, 2, 0, 0, 0, 1, 0});
+  // [0 0 0 1 1 3 3 4 4]
+  test::FillValues<int64>(&sp_indices, {0, 1, 0, 3, 0, 6, 1, 3, 1, 6,
+                                        3, 3, 3, 4, 4, 1, 4, 7});
+  test::FillValues<int64>(&sp_dense_shape, {batch_size, entries});
+  test::FillValues<float>(
+      &emb_variable,
+      {-0.023765106, -0.248630840,  0.275294270, 0.228118000,
+       -0.147108670, -0.298352200, -0.067187610, 0.274558250,
+        0.491792620, -0.094891705,  0.064489834, 0.058840238});
+  
+  AddInputFromArray<float>(emb_variable.shape(), emb_variable.flat<float>());
+  AddInputFromArray<int64>(sp_values.shape(), sp_values.flat<int64>());
+  AddInputFromArray<int64>(sp_dense_shape.shape(),
+                            sp_dense_shape.flat<int64>());
+  AddInputFromArray<int64>(sp_indices.shape(), sp_indices.flat<int64>());
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor emb_vector_expected(DT_FLOAT, {batch_size, emb_vector_dim});
+
+  test::FillValues<float>(&emb_vector_expected,
+      {-0.19463888, -0.79561390, 0.48340094, 0.73079425,
+        0.46802750, -0.34352255, 0.33978412, 0.28695825,
+        0.00000000,  0.00000000, 0.00000000, 0.00000000,
+       -0.04753021, -0.49726167, 0.55058855, 0.45623600,
+       -0.17087378, -0.54698306, 0.20810667, 0.50267625});
+
+  const Tensor& emb_vector = *GetOutput(0);
+
+  float *output = (float *)emb_vector.tensor_data().data();
+  float *output_ex = (float *)emb_vector_expected.tensor_data().data();
+
+  test::ExpectTensorNear<float>(emb_vector_expected, emb_vector, 1e-8);
+}
+
+TEST_F(FusedEmbeddingLocalSparseLookUpOpTest, FloatMeanCpu) {
+
+  TF_EXPECT_OK(NodeDefBuilder("FusedSafeEmbeddingLookupSparse",
+                              "FusedSafeEmbeddingLookupSparse")
+                    .Input(FakeInput(DT_FLOAT))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Attr("T", DT_FLOAT)
+                    .Attr("combiner", "mean")
+                    .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  const int nnz = 9;
+  const int batch_size = 5;
+  const int emb_vector_dim = 4;
+  const int entries = 8;
+  const int gathered_weight_size = 3;
+
+  Tensor sp_values(DT_INT64, {nnz});
+  Tensor sp_weight(DT_INT64, {nnz});
+  Tensor sp_indices(DT_INT64, {nnz, 2});
+  Tensor sp_dense_shape(DT_INT64, {2});
+  Tensor emb_variable(DT_FLOAT, {gathered_weight_size, emb_vector_dim});
+
+  // [1 1 0 4 1 1 1 0 1] -> [1 0 4], [0 0 1 2 0 0 0 1 0]
+  test::FillValues<int64>(&sp_values, {0, 0, 1, 2, 0, 0, 0, 1, 0});
+  test::FillValues<int64>(&sp_weight, {0, 0, 1, 2, 0, 0, 0, 1, 0});
+  // [0 0 0 1 1 3 3 4 4]
+  test::FillValues<int64>(&sp_indices, {0, 1, 0, 3, 0, 6, 1, 3, 1, 6,
+                                        3, 3, 3, 4, 4, 1, 4, 7});
+  test::FillValues<int64>(&sp_dense_shape, {batch_size, entries});
+  test::FillValues<float>(
+      &emb_variable,
+      {-0.02299355, -0.247596220,  0.27484232, 0.226618130,
+       -0.14686598, -0.297978460, -0.06733219, 0.273977040,
+        0.49191360, -0.094738655,  0.06426916, 0.058573183});
+
+  AddInputFromArray<float>(emb_variable.shape(), emb_variable.flat<float>());
+  AddInputFromArray<int64>(sp_values.shape(), sp_values.flat<int64>());
+  AddInputFromArray<int64>(sp_dense_shape.shape(),
+                            sp_dense_shape.flat<int64>());
+  AddInputFromArray<int64>(sp_indices.shape(), sp_indices.flat<int64>());
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor emb_vector_expected(DT_FLOAT, {batch_size, emb_vector_dim});
+  test::FillValues<float>(&emb_vector_expected,
+      {-0.064284360, -0.26439032, 0.160784140, 0.24240442,
+        0.234460030, -0.17116743, 0.169555740, 0.14259565,
+        0.000000000,  0.00000000, 0.000000000, 0.00000000,
+       -0.022993550, -0.24759622, 0.274842320, 0.22661813,
+       -0.084929764, -0.27278733, 0.103755064, 0.25029758});
+
+  const Tensor& emb_vector = *GetOutput(0);
+
+  float *output = (float *)emb_vector.tensor_data().data();
+  float *output_ex = (float *)emb_vector_expected.tensor_data().data();
+
+  test::ExpectTensorNear<float>(emb_vector_expected, emb_vector, 1e-7);
+}
+
+TEST_F(FusedEmbeddingLocalSparseLookUpOpTest, GradFloatSumCpu) {
+
+  TF_EXPECT_OK(NodeDefBuilder("FusedSafeEmbeddingLookupSparseGrad",
+                              "FusedSafeEmbeddingLookupSparseGrad")
+                    .Input(FakeInput(DT_FLOAT)) // gradients
+                    .Input(FakeInput(DT_INT64)) // unique_id
+                    .Input(FakeInput(DT_INT64)) // unique_indices
+                    .Input(FakeInput(DT_INT64)) // dense_shape
+                    .Input(FakeInput(DT_INT64)) // indices
+                    .Attr("T", DT_FLOAT)
+                    .Attr("Tinput", DT_INT64)
+                    .Attr("Tindices", DT_INT64)
+                    .Attr("Tdense_shape", DT_INT64)
+                    .Attr("combiner", "sum")
+                    .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  const int unique_size = 3;
+  const int nnz = 9;
+  const int batch_size = 5;
+  const int emb_vector_dim = 4;
+  const int entries = 8;
+
+  Tensor unique_id(DT_INT64, {unique_size});
+  Tensor unique_indices(DT_INT64, {nnz});
+  Tensor sp_indices(DT_INT64, {nnz, 2});
+  Tensor sp_dense_shape(DT_INT64, {2});
+  Tensor grad_variable(DT_FLOAT, {batch_size, emb_vector_dim});
+
+  test::FillValues<float>(
+      &grad_variable,
+      {0.0076283700764179229736328125, 0.0121669657528400421142578125, -0.0049919090233743190765380859, -0.0190300568938255310058593750,
+       0.0065145129337906837463378906, 0.0117923058569431304931640625, -0.0164990965276956558227539062, -0.0200323350727558135986328125,
+       0.0100607946515083312988281250, 0.0153625328093767166137695312, -0.0056031607091426849365234375, -0.0249206330627202987670898438,
+       0.0099571626633405685424804688, 0.0154269225895404815673828125, -0.0055019007995724678039550781, -0.0239365808665752410888671875,
+       0.0084272380918264389038085938, 0.0152924191206693649291992188, -0.0086676068603992462158203125, -0.0239860229194164276123046875});
+  test::FillValues<int64>(&unique_id, {1, 0, 4});
+  test::FillValues<int64>(&unique_indices, {0, 0, 1, 2, 0, 0, 0, 1, 0});
+  test::FillValues<int64>(&sp_indices, {0, 1, 0, 3, 0, 6, 1, 3, 1, 6,
+                                        3, 3, 3, 4, 4, 1, 4, 7});
+  test::FillValues<int64>(&sp_dense_shape, {batch_size, entries});
+
+  AddInputFromArray<float>(grad_variable.shape(), grad_variable.flat<float>());
+  AddInputFromArray<int64>(unique_id.shape(), unique_id.flat<int64>());
+  AddInputFromArray<int64>(unique_indices.shape(), unique_indices.flat<int64>());
+  AddInputFromArray<int64>(sp_indices.shape(), sp_indices.flat<int64>());
+  AddInputFromArray<int64>(sp_dense_shape.shape(), sp_dense_shape.flat<int64>());
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor output1_tensor_expected(DT_FLOAT, {unique_size, emb_vector_dim});
+  Tensor output2_tensor_expected(DT_INT64, {unique_size});
+  test::FillValues<float>(&output1_tensor_expected,
+      {0.0501128211617469787597656250, 0.0822724997997283935546875000, -0.0461543202400207519531250000, -0.1299516409635543823242187500,
+       0.0160556081682443618774414062, 0.0274593848735094070434570312, -0.0136595163494348526000976562, -0.0430160798132419586181640625,
+       0.0065145129337906837463378906, 0.0117923058569431304931640625, -0.0164990965276956558227539062, -0.0200323369354009628295898438});
+  test::FillValues<int64>(&output2_tensor_expected, {1, 0, 4});
+  float *output1_ex = (float *)output1_tensor_expected.tensor_data().data();
+  int64 *output2_ex = (int64 *)output2_tensor_expected.tensor_data().data();
+
+  const Tensor& output1_tensor = *GetOutput(0);
+  const Tensor& output2_tensor = *GetOutput(1);
+
+  float *output1 = (float *)output1_tensor.tensor_data().data();
+  int64 *output2 = (int64 *)output2_tensor.tensor_data().data();
+
+  printf("out = %.28f , expect = %.28f\n", output1[11], output1_ex[11]);
+
+  test::ExpectTensorNear<float>(output1_tensor_expected, output1_tensor, 1e-8);
+  test::ExpectTensorEqual<int64>(output2_tensor_expected, output2_tensor);
+}
+
+TEST_F(FusedEmbeddingLocalSparseLookUpOpTest, GradFloatMeanCpu) {
+
+  TF_EXPECT_OK(NodeDefBuilder("FusedSafeEmbeddingLookupSparseGrad",
+                              "FusedSafeEmbeddingLookupSparseGrad")
+                    .Input(FakeInput(DT_FLOAT)) // gradients
+                    .Input(FakeInput(DT_INT64)) // unique_id
+                    .Input(FakeInput(DT_INT64)) // unique_indices
+                    .Input(FakeInput(DT_INT64)) // dense_shape
+                    .Input(FakeInput(DT_INT64)) // indices
+                    .Attr("T", DT_FLOAT)
+                    .Attr("Tinput", DT_INT64)
+                    .Attr("Tindices", DT_INT64)
+                    .Attr("Tdense_shape", DT_INT64)
+                    .Attr("combiner", "mean")
+                    .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  const int unique_size = 3;
+  const int nnz = 9;
+  const int batch_size = 5;
+  const int emb_vector_dim = 4;
+  const int entries = 8;
+
+  Tensor unique_id(DT_INT64, {unique_size});
+  Tensor unique_indices(DT_INT64, {nnz});
+  Tensor sp_indices(DT_INT64, {nnz, 2});
+  Tensor sp_dense_shape(DT_INT64, {2});
+  Tensor grad_variable(DT_FLOAT, {batch_size, emb_vector_dim});
+
+  test::FillValues<float>(
+      &grad_variable,
+      {0.0103125420, 0.018807490, -0.0106398590, -0.029409127,
+       0.0054132286, 0.013920069, -0.0190976150, -0.023196392,
+       0.0100601720, 0.015330995, -0.0055795530, -0.024889620,
+       0.0108455080, 0.018832123, -0.0095151365, -0.029357582,
+       0.0100478110, 0.018798435, -0.0112019650, -0.029439624});
+  test::FillValues<int64>(&unique_id, {1, 0, 4});
+  test::FillValues<int64>(&unique_indices, {0, 0, 1, 2, 0, 0, 0, 1, 0});
+  test::FillValues<int64>(&sp_indices, {0, 1, 0, 3, 0, 6, 1, 3, 1, 6,
+                                        3, 3, 3, 4, 4, 1, 4, 7});
+  test::FillValues<int64>(&sp_dense_shape, {batch_size, entries});
+
+  AddInputFromArray<float>(grad_variable.shape(), grad_variable.flat<float>());
+  AddInputFromArray<int64>(unique_id.shape(), unique_id.flat<int64>());
+  AddInputFromArray<int64>(unique_indices.shape(), unique_indices.flat<int64>());
+  AddInputFromArray<int64>(sp_indices.shape(), sp_indices.flat<int64>());
+  AddInputFromArray<int64>(sp_dense_shape.shape(), sp_dense_shape.flat<int64>());
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor output1_tensor_expected(DT_FLOAT, {unique_size, emb_vector_dim});
+  Tensor output2_tensor_expected(DT_INT64, {unique_size});
+  test::FillValues<float>(&output1_tensor_expected,
+      {0.0254510570, 0.0477297000, -0.0317581670, -0.075281680,
+       0.0084614195, 0.0156683810, -0.0091476020, -0.024522856,
+       0.0027066143, 0.0069600344, -0.0095488075, -0.011598196});
+  test::FillValues<int64>(&output2_tensor_expected, {1, 0, 4});
+  float *output1_ex = (float *)output1_tensor_expected.tensor_data().data();
+  int64 *output2_ex = (int64 *)output2_tensor_expected.tensor_data().data();
+
+  const Tensor& output1_tensor = *GetOutput(0);
+  const Tensor& output2_tensor = *GetOutput(1);
+
+  float *output1 = (float *)output1_tensor.tensor_data().data();
+  int64 *output2 = (int64 *)output2_tensor.tensor_data().data();
+
+  test::ExpectTensorNear<float>(output1_tensor_expected, output1_tensor, 1e-8);
+  test::ExpectTensorEqual<int64>(output2_tensor_expected, output2_tensor);
+}
+
+}  // namespace
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_op.h
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_op.h
@@ -1,0 +1,13 @@
+#ifndef TENSORFLOW_CORE_KERNELS_FUSED_EMBEDDING_embedding_EMBEDDING_LOOKUP_SPARSE_OP_H_
+#define TENSORFLOW_CORE_KERNELS_FUSED_EMBEDDING_embedding_EMBEDDING_LOOKUP_SPARSE_OP_H_
+
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "tensorflow/core/framework/tensor_types.h"
+
+namespace tensorflow {
+namespace functor {
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_FUSED_EMBEDDING_embedding_EMBEDDING_LOOKUP_SPARSE_OP_H_

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_grad_op_test.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_grad_op_test.cc
@@ -1,0 +1,243 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/platform/test_benchmark.h"
+#include "tensorflow/core/public/session.h"
+
+namespace tensorflow {
+namespace {
+
+enum class Device { CPU, GPU };
+
+class FusedSafeEmbeddingPostLookupGradOpTest : public OpsTestBase {
+ protected:
+  void MakeOpAndSetDevice(Device device, int num_partitions, DataType dtype,
+                          const std::string& combiner, const float max_norm,
+                          const int default_id) {
+    if (device == Device::GPU) {
+      SetDevice(DEVICE_GPU,
+                std::unique_ptr<tensorflow::Device>(DeviceFactory::NewDevice(
+                    "GPU", {}, "/job:a/replica:0/task:0")));
+    }
+
+    TF_EXPECT_OK(NodeDefBuilder("fused_safe_embedding_post_look_up_grad",
+                                "FusedEmbeddingSparsePostLookUpGrad")
+                     .Attr("T", dtype)
+                     .Attr("num_partitions", num_partitions)
+                     .Attr("partition_axis", 0)
+                     .Attr("combiner", combiner)
+                     .Attr("max_norm", max_norm)
+                     .Attr("default_id", default_id)
+                     .Input(FakeInput(dtype))
+                     .Input(FakeInput(dtype))
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(DT_INT32))
+                     .Input(FakeInput(DT_INT32))
+                     .Finalize(node_def()));
+    TF_EXPECT_OK(InitOp());
+  }
+};
+
+TEST_F(FusedSafeEmbeddingPostLookupGradOpTest,
+       Partition2_Mean_MaxNorm100_Float) {
+  const int nnz = 10;
+  const int batch_size = 4;
+  const int emb_vector_dim = 8;
+  const int entries = 8;
+
+  MakeOpAndSetDevice(Device::CPU, 2, DT_FLOAT, "mean", 100.0, -1);
+
+  // top_grad
+  AddInputFromArray<float>(
+      TensorShape({batch_size, emb_vector_dim}),
+      {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0,
+       11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0,
+       22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0});
+
+  // emb_shards
+  AddInputFromArray<float>(
+      TensorShape({6, emb_vector_dim}),
+      {8.0,  9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 24.0, 25.0, 26.0, 27.0,
+       28.0, 29.0, 30.0, 31.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0,
+       32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 32.0, 33.0, 34.0, 35.0,
+       36.0, 37.0, 38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0});
+  AddInputFromArray<float>(
+      TensorShape({4, emb_vector_dim}),
+      {56.0,  57.0,  58.0,  59.0,  60.0,  61.0,  62.0,  63.0,
+       96.0,  97.0,  98.0,  99.0,  100.0, 101.0, 102.0, 103.0,
+       96.0,  97.0,  98.0,  99.0,  100.0, 101.0, 102.0, 103.0,
+       120.0, 121.0, 122.0, 123.0, 124.0, 125.0, 126.0, 127.0});
+
+  // sp_values: 3, 1, 4, 5, 7, 3, 12, 12, 15, 4
+  // partitioned_values: 1, 3, 3, 4, 4, 5 and 7, 12, 12, 15
+  // partitioned_indices
+  AddInputFromArray<int64>(TensorShape({6, 2}),
+                           {0, 5, 0, 1, 2, 1, 1, 2, 3, 6, 1, 1});
+  AddInputFromArray<int64>(TensorShape({4, 2}), {1, 7, 2, 4, 2, 7, 3, 0});
+
+  // feature_nums
+  AddInputFromArray<int>(TensorShape({batch_size}), {2, 3, 3, 2});
+
+  // row_empty_and_invalid_flags
+  AddInputFromArray<int>(TensorShape({batch_size + nnz}),
+                         {0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+
+  {
+    Tensor grad_shards_1(allocator(), DT_FLOAT,
+                         TensorShape({6, emb_vector_dim}));
+    test::FillValues<float>(
+        &grad_shards_1,
+        {0.00000000,  0.50000000,  1.00000000,  1.50000000,  2.00000000,
+         2.50000000,  3.00000000,  3.50000000,  0.00000000,  0.50000000,
+         1.00000000,  1.50000000,  2.00000000,  2.50000000,  3.00000000,
+         3.50000000,  5.33333349,  5.66666651,  6.00000000,  6.33333349,
+         6.66666651,  7.00000000,  7.33333349,  7.66666651,  2.65028572,
+         2.98157120,  3.31285667,  3.64414287,  3.97542834,  4.30671406,
+         4.63799953,  4.96928549,  11.92628479, 12.42321396, 12.92014217,
+         13.41707039, 13.91399956, 14.41092777, 14.90785599, 15.40478516,
+         2.16437674,  2.43492365,  2.70547056,  2.97601795,  3.24656487,
+         3.51711202,  3.78765893,  4.05820608});
+    test::ExpectTensorNear<float>(grad_shards_1, *GetOutput(0), 1e-4);
+  }
+
+  {
+    Tensor grad_shards_2(allocator(), DT_FLOAT,
+                         TensorShape({4, emb_vector_dim}));
+    test::FillValues<float>(
+        &grad_shards_2,
+        {1.58337951, 1.78130186, 1.97922409, 2.17714667, 2.37506914, 2.57299161,
+         2.77091384, 2.96883631, 1.89459133, 2.01300311, 2.13141513, 2.24982715,
+         2.36823893, 2.48665094, 2.60506320, 2.72347474, 1.89459133, 2.01300311,
+         2.13141513, 2.24982715, 2.36823893, 2.48665094, 2.60506320, 2.72347474,
+         3.43474555, 3.57786012, 3.72097445, 3.86408877, 4.00720310, 4.15031767,
+         4.29343224, 4.43654633});
+    test::ExpectTensorNear<float>(grad_shards_2, *GetOutput(1), 1e-4);
+  }
+}
+
+TEST_F(FusedSafeEmbeddingPostLookupGradOpTest,
+       Partition2_SUM_Float_No_Default) {
+  const int nnz = 3;
+  const int batch_size = 3;
+  const int emb_vector_dim = 4;
+  const int entries = 8;
+
+  MakeOpAndSetDevice(Device::CPU, 2, DT_FLOAT, "sum", -1.0, -1);
+
+  // top_grad
+  AddInputFromArray<float>(
+      TensorShape({batch_size, emb_vector_dim}),
+      {1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0});
+
+  // emb_shards
+  AddInputFromArray<float>(TensorShape({2, emb_vector_dim}),
+                           {8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0});
+  AddInputFromArray<float>(TensorShape({2, emb_vector_dim}),
+                           {56.0, 57.0, 58.0, 59.0, 60.0, 61.0, 62.0, 63.0});
+
+  // partitioned_indices
+  AddInputFromArray<int64>(TensorShape({2, 2}), {0, 0, 0, 5});
+  AddInputFromArray<int64>(TensorShape({2, 2}), {1, 4, 2, 0});
+
+  // feature_nums
+  AddInputFromArray<int>(TensorShape({batch_size}), {2, 1, 1});
+
+  // row_empty_and_invalid_flags
+  AddInputFromArray<int>(TensorShape({batch_size + nnz}), {0, 0, 1, 1, 1, 1});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+
+  {
+    Tensor grad_shards_1(allocator(), DT_FLOAT,
+                         TensorShape({2, emb_vector_dim}));
+    test::FillValues<float>(&grad_shards_1,
+                            {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0});
+    test::ExpectTensorNear<float>(grad_shards_1, *GetOutput(0), 1e-4);
+  }
+
+  {
+    Tensor grad_shards_2(allocator(), DT_FLOAT,
+                         TensorShape({2, emb_vector_dim}));
+    test::FillValues<float>(&grad_shards_2,
+                            {2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0});
+    test::ExpectTensorNear<float>(grad_shards_2, *GetOutput(1), 1e-4);
+  }
+}
+
+TEST_F(FusedSafeEmbeddingPostLookupGradOpTest,
+       Partition2_SUM_Float_Default_0) {
+  const int nnz = 3;
+  const int batch_size = 3;
+  const int emb_vector_dim = 4;
+  const int entries = 8;
+
+  MakeOpAndSetDevice(Device::CPU, 2, DT_FLOAT, "sum", -1.0, 0);
+
+  // top_grad
+  AddInputFromArray<float>(
+      TensorShape({batch_size, emb_vector_dim}),
+      {1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0});
+
+  // emb_shards
+  AddInputFromArray<float>(TensorShape({2, emb_vector_dim}),
+                           {8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0});
+  AddInputFromArray<float>(TensorShape({2, emb_vector_dim}),
+                           {56.0, 57.0, 58.0, 59.0, 60.0, 61.0, 62.0, 63.0});
+
+  // partitioned_indices
+  AddInputFromArray<int64>(TensorShape({2, 2}), {0, 0, 0, 5});
+  AddInputFromArray<int64>(TensorShape({2, 2}), {1, 4, 2, 0});
+
+  // feature_nums
+  AddInputFromArray<int>(TensorShape({batch_size}), {2, 1, 1});
+
+  // row_empty_and_invalid_flags
+  AddInputFromArray<int>(TensorShape({batch_size + nnz}), {0, 0, 1, 1, 1, 1});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+
+  {
+    Tensor grad_shards_1(allocator(), DT_FLOAT,
+                         TensorShape({2, emb_vector_dim}));
+    test::FillValues<float>(&grad_shards_1,
+                            {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0});
+    test::ExpectTensorNear<float>(grad_shards_1, *GetOutput(0), 1e-4);
+  }
+
+  {
+    Tensor grad_shards_2(allocator(), DT_FLOAT,
+                         TensorShape({2, emb_vector_dim}));
+    test::FillValues<float>(&grad_shards_2,
+                            {2.0, 2.0, 2.0, 2.0, 0.0, 0.0, 0.0, 0.0});
+    test::ExpectTensorNear<float>(grad_shards_2, *GetOutput(1), 1e-4);
+  }
+}
+
+}  // namespace
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_op.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_op.cc
@@ -1,0 +1,590 @@
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/resource_mgr.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/resource_var.h"
+#include "tensorflow/core/framework/bounds_check.h"
+
+namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+enum SparseSegmentReductionOperation { kSum, kMean, kSqrtN };
+
+namespace {
+    // input: input tensor value (it sores the id)
+    // cols: How many elements to do SparseSegmentSum
+    // output: rows * embedding_size
+    template<typename T>
+    static void sparse_gather_v1(T *input, int rows, int cols,
+                                float *embedding_table, float *output,
+                                int embedding_size, bool is_mean) {
+      T *pidx = input;
+      for (int i = 0; i < rows; ++i) {
+        for (int j = 0; j < embedding_size; ++j) {
+          float value = 0;
+          int dense_num = 0;
+          for (int k = 0; k < cols; ++k) {
+            int embedding_row = (int)pidx[k];
+            if (embedding_row >= 0) {
+              value += embedding_table[embedding_row * embedding_size + j];
+              dense_num += 1;
+            }
+          }
+
+          if (is_mean && dense_num > 0) {
+              *output++ = value / dense_num;
+          } else {
+              *output++ = value;
+          }
+        }
+        pidx += cols;
+      }
+    }
+
+    // embedding_size = 1
+    template<typename T>
+    static void sparse_gather_embeddingsize1(T *input, int rows, int cols,
+                                            float *embedding_table, float *output,
+                                            bool is_mean) {
+    T *pidx = input;
+    for (int i = 0; i < rows; ++i) {
+      float value = 0;
+      int dense_num = 0;
+      for (int k = 0; k < cols; ++k) {
+        int embedding_row = pidx[k];
+        if (embedding_row >= 0) {
+            value += embedding_table[embedding_row];
+            dense_num += 1;
+        }
+      }
+      if (is_mean && dense_num > 0) {
+        *output++ = value / dense_num;
+      } else {
+        *output++ = value;
+      }
+      pidx += cols;
+    }
+    }
+
+    // input cols = 1
+    template<typename T>
+    static void sparse_gather_column1(T *input, int rows, float *embedding_table,
+                            float *output, int embedding_size) {
+    T *pidx = input;
+    for (int i = 0; i < rows; ++i) {
+        int embedding_row = *pidx++;
+        if (embedding_row >= 0) {
+        float *pembedding = &embedding_table[embedding_row * embedding_size];
+        for (int j = 0; j < embedding_size; ++j) {
+            output[j] = pembedding[j];
+        }
+        } else {
+        for (int j = 0; j < embedding_size; ++j) {
+            output[j] = 0;
+        }
+        }
+        output += embedding_size;
+    }
+    }
+
+    template<typename T>
+    static void sparse_gather(T *input, int rows, int cols, float *embedding_table,
+                            float *output, int embedding_size, bool is_mean) {
+      if (embedding_size == 1) {
+        sparse_gather_embeddingsize1(input, rows, cols, embedding_table, output,
+                                      is_mean);
+      } else if (cols == 1) {
+        sparse_gather_column1(input, rows, embedding_table, output, embedding_size);
+      } else {
+        //printf("General sparse gather!\n");
+        sparse_gather_v1(input, rows, cols, embedding_table, output, embedding_size,
+                        is_mean);
+      }
+    }
+
+    // Use memcpy or manually assign?
+    static void mycopy(float *dst, float *src, int float_num) {
+      memcpy(dst, src, float_num * sizeof(float));
+    }
+
+    static void myadd(float *dst, float *src, int float_num) {
+      for (int i = 0; i < float_num; ++i) {
+        dst[i] += src[i];
+      }
+    }
+
+    template<typename T>
+    static void row_add(std::map<T *, std::vector<const T *>> &mapSet, int64 row_nums) {
+
+      for (auto it = mapSet.begin(); it != mapSet.end(); ++it){
+        T * dst = it->first;
+        std::vector<const T *> srcs(std::move(it->second));
+        int64 src_size = srcs.size();
+
+        for (int row = 0; row < row_nums; ++row){
+          dst[row] = 0.0;
+          for (int index = 0; index < src_size; ++index) {
+            dst[row] += srcs[index][row];
+          }
+        }
+      }
+    }
+
+    template<typename T>
+    static void row_add_mean(std::map<T *, std::vector<const T *>> &mapSet, int64 row_nums, bool is_mean) {
+
+#define L(n) srcs[index + n][row]
+
+      for (auto it = mapSet.begin(); it != mapSet.end(); ++it){
+        T * dst = it->first;
+        std::vector<const T *> srcs(std::move(it->second));
+        int64 src_size = srcs.size();
+
+        if (src_size==1){
+          for (int row = 0; row < row_nums; ++row){
+            dst[row] = srcs[0][row];
+          }
+          continue;
+        }
+
+        float sum_tmp = 0.0;
+        int64 index = 0;
+        int64 r = (src_size) % 8;
+        int64 m = 1;
+        if (src_size < 10 && is_mean) m = src_size;
+
+        for (int row = 0; row < row_nums; ++row){
+          sum_tmp = 0.0;
+          index = 0;
+          dst[row] = 0.0;
+          switch (r) {
+            case 2: {
+              sum_tmp = (L(0) + L(1)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 3: {
+              sum_tmp = (L(0) + L(1) + L(2)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 4: {
+              sum_tmp = (L(0) + L(1) + L(2) + L(3)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 5: {
+              sum_tmp = (L(0) + L(1) + L(2) + L(3) + L(4)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 6: {
+              sum_tmp = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 7: {
+              sum_tmp = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6)) / m;
+              dst[row] = sum_tmp;
+              break;
+            }
+            case 0: {
+              dst[row] = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6) + L(7)) / m;
+              index += 8;
+              break;
+            }
+            case 1: {
+              dst[row] = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6) + L(7) + L(8)) / m;
+              index += 8;
+              break;
+            }
+          }
+          for (index += r; index < src_size; index += 8) {
+            sum_tmp = L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6) + L(7);
+            dst[row] += sum_tmp;
+          }
+          if (src_size >= 10 && is_mean) dst[row] /= src_size;
+        }
+      }
+    }
+
+    static void myscale(float *dst, float factor, int float_num) {
+      for (int i = 0; i < float_num; ++i) {
+          dst[i] *= factor;
+      }
+    }
+
+    static void sparse_gather(int64 *input, int64 input_size, int64 *indice,
+                            int indice_dim, int64 *shape, int rows, int cols,
+                            float *embedding_table, float *output,
+                            int embedding_size, bool is_mean) {
+      // Record how many values in each row
+      int *row_values = new int[rows];
+      memset(row_values, 0, rows * sizeof(int));
+
+      std::map<float *, std::vector<const float *>> mapSet;
+
+      for (int64 i = 0; i < input_size; ++i) {
+        int64 id = input[i];
+        if (i < input_size && input[i] < 0) { // Skip invalid id
+          continue;
+        }
+        auto row = indice[i * indice_dim];
+        // for (int k = 1; k < indice_dim - 1; ++k) {
+        //   row = row * shape[k] + indice[i * indice_dim + k];
+        // }
+        row_values[row] += 1;
+
+        auto index = row * embedding_size;
+        if (!mapSet.count(&output[index])){
+          std::vector<const float *> srcs;
+          mapSet[&output[index]] = srcs;
+        }
+        mapSet[&output[index]].push_back(&embedding_table[id * embedding_size]);
+      }
+
+      // row_add(mapSet, embedding_size);
+      row_add_mean(mapSet, embedding_size, is_mean);
+
+      for (int i = 0; i < rows; ++i) {
+        if (row_values[i] == 0) {
+          memset(&output[i * embedding_size], 0, embedding_size * sizeof(float));
+        // } else if (is_mean && row_values[i] > 1) {
+        //   float factor = 1.0f / row_values[i];
+        //   myscale(&output[i * embedding_size], factor, embedding_size);
+        }
+      }
+      delete[] row_values;
+    }
+
+    int64 partitioned_indices(std::vector<std::tuple<size_t, const int64*>> indices, int indice_dim, int64 id) {
+        int indices_num = indices.size();
+        int64 rows = 0;
+        for (int i = 0; i < indices_num; ++i) {
+            rows += std::get<0>(indices[i]);
+            if (rows > id) {
+                int idx = id - (rows - std::get<0>(indices[i]));
+                return std::get<1>(indices[i])[idx * indice_dim];
+            }
+        }
+    }
+
+    const float* partitioned_embedding_tables(std::vector<std::tuple<size_t, const float*>> embedding_tables, int embedding_size, int64 id) {
+        int tables_num = embedding_tables.size();
+        int64 rows = 0;
+        for (int i = 0; i < tables_num; ++i) {
+            rows += std::get<0>(embedding_tables[i]);
+            if (rows > id) {
+                int idx = id - (rows - std::get<0>(embedding_tables[i]));
+                return &(std::get<1>(embedding_tables[i])[idx * embedding_size]);
+            }
+        }
+    }
+
+    static void sparse_partitioned_gather(int64 input_size, std::vector<std::tuple<size_t, const int64*>> &indices,
+                            int indice_dim, int rows,
+                            std::vector<std::tuple<size_t, const float*>> &embedding_tables, float *output,
+                            const int64_t embedding_size, SparseSegmentReductionOperation operation,
+                            const bool set_empty_row_zero, const int *empty_row) {
+      // Record how many values in each row
+      int *row_values = new int[rows];
+      memset(row_values, 0, rows * sizeof(int));
+
+      std::map<float *, std::vector<const float *>> mapSet;
+
+      // sum
+      for (int64 i = 0; i < input_size; ++i) {
+        int64 id = i;
+        auto row = partitioned_indices(indices, indice_dim, i);
+        row_values[row] += 1;
+
+        auto index = row * embedding_size;
+        if (!mapSet.count(&output[index])){
+          std::vector<const float *> srcs;
+          mapSet[&output[index]] = srcs;
+        }
+        mapSet[&output[index]].push_back(partitioned_embedding_tables(embedding_tables, embedding_size, id));
+      }
+
+      row_add_mean(mapSet, embedding_size, operation == SparseSegmentReductionOperation::kMean);
+
+      for (int i = 0; i < rows; ++i) {
+        // zero emtpy rows
+        if (set_empty_row_zero && empty_row[i] == 1) {
+            memset(&output[i * embedding_size], 0, embedding_size * sizeof(float));;
+        }
+
+        if (row_values[i] == 0) {
+          memset(&output[i * embedding_size], 0, embedding_size * sizeof(float));
+        } else if (operation == SparseSegmentReductionOperation::kMean && row_values[i] > 1) {
+          // float factor = 1.0f / row_values[i];
+          // myscale(&output[i * embedding_size], factor, embedding_size);
+        } else if (operation == SparseSegmentReductionOperation::kSqrtN && row_values[i] > 1) {
+          //fixme(marvin): shall we need care the data precision like "mean"? 
+          float factor = 1.0f / std::sqrt(row_values[i]);
+          myscale(&output[i * embedding_size], factor, embedding_size);
+        }
+      }
+      delete[] row_values;
+    }
+
+    static void set_feature_nums(int32 *feature_nums, int64 input_size, std::vector<std::tuple<size_t, const int64*>> indices, int indice_dim) {
+        for (int64 i = 0; i < input_size; ++i) {
+            feature_nums[partitioned_indices(indices, indice_dim, i)]++;
+        }
+    }
+}
+
+
+
+template <typename Device>
+class FusedSafeEmbeddingPostLookupOp : public OpKernel {
+public:
+  explicit FusedSafeEmbeddingPostLookupOp(OpKernelConstruction* ctx)
+           : OpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("num_partitions", &num_partitions_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("partition_axis", &partition_axis_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("combiner", &combiner_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("max_norm", &max_norm_));
+    int temp_default_id;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("default_id", &temp_default_id));
+    default_id_ = int64_t(temp_default_id);
+    if (combiner_ == "sum") {
+      operation_ = SparseSegmentReductionOperation::kSum;
+    } else if (combiner_ == "mean") {
+      operation_ = SparseSegmentReductionOperation::kMean;
+    } else if (combiner_ == "sqrtn") {
+      operation_ = SparseSegmentReductionOperation::kSqrtN;
+    } else {
+      OP_REQUIRES(ctx, false,
+          errors::InvalidArgument("Currently, 'mean', 'sqrtn' and 'sum' are only supported"));
+    }
+  }
+
+  ~FusedSafeEmbeddingPostLookupOp() {}
+
+  void Compute(OpKernelContext* ctx) override {
+    OpInputList emb_shards;
+    OP_REQUIRES_OK(ctx, ctx->input_list("emb_shards", &emb_shards));
+
+    OpInputList partitioned_indices;
+    OP_REQUIRES_OK(
+        ctx, ctx->input_list("partitioned_indices", &partitioned_indices));
+
+    Tensor const* dense_shape_tensor = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->input("sp_dense_shape", &dense_shape_tensor));
+
+    Tensor const* row_empty_and_invalid_flags = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->input("row_empty_and_invalid_flags",
+                                   &row_empty_and_invalid_flags));
+
+    const int64_t embedding_size = emb_shards[0].shape().dim_size(1);
+
+    int input_dims = dense_shape_tensor->dim_size(0);
+    int batch_size = 1;
+    for (int i = 0; i < input_dims - 1; ++i) {
+      batch_size *= dense_shape_tensor->flat<int64>().data()[i];
+    }
+
+    // To check the input
+    OP_REQUIRES(ctx, (dense_shape_tensor->dims() == 1),
+                errors::InvalidArgument("Shape tensor is not valid (dims != 1)"));
+    OP_REQUIRES(ctx, (dense_shape_tensor->dim_size(0) >= 2),
+                errors::InvalidArgument("Shape tensor is not valid (dim_size(0) < 2)"));
+
+    const int *empty_row = row_empty_and_invalid_flags->flat<int>().data();
+
+    Tensor* emb_vectors_tensor = nullptr;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_output(0, TensorShape({batch_size, embedding_size}),
+                                  &emb_vectors_tensor));
+    float *output = (float *)emb_vectors_tensor->tensor_data().data();
+
+    Tensor* feature_nums_tensor;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_output(1, TensorShape({batch_size}), &feature_nums_tensor));
+    int32 *feature_nums = (int32 *)feature_nums_tensor->tensor_data().data();
+    memset(feature_nums, 0, batch_size*sizeof(int32));
+
+    int64 input_size = 0;
+    for (int i = 0; i < num_partitions_; ++i) {
+      input_size += partitioned_indices[i].shape().dim_size(0);
+    }
+
+    int indice_dim = partitioned_indices[0].shape().dim_size(1);
+
+    const bool set_empty_row_zero = default_id_ >= 0;
+
+    std::vector<std::tuple<size_t, const float*>> embedding_tables;
+    std::vector<std::tuple<size_t, const int64*>> indices;
+    embedding_tables.reserve(num_partitions_);
+    indices.reserve(num_partitions_);
+    for (int i = 0; i < num_partitions_; i++) {
+      const size_t sub_nnz = emb_shards[i].shape().dim_size(0);
+      OP_REQUIRES(
+          ctx, sub_nnz == partitioned_indices[i].shape().dim_size(0),
+          errors::InvalidArgument(
+              "emb_shard and partitioned_indice dosn't have the same length"));
+      embedding_tables.emplace_back(std::make_tuple(sub_nnz, emb_shards[i].flat<float>().data()));
+      indices.emplace_back(std::make_tuple(sub_nnz, partitioned_indices[i].flat<int64>().data()));
+    }
+
+    sparse_partitioned_gather(input_size, indices, indice_dim, batch_size,
+            embedding_tables, output, embedding_size, operation_, set_empty_row_zero, empty_row);
+    set_feature_nums(feature_nums, input_size, indices, indice_dim);
+  }
+
+private:
+int num_partitions_;
+  int partition_axis_;
+  std::string combiner_;
+  float max_norm_;
+  int64_t default_id_;
+  SparseSegmentReductionOperation operation_;
+};
+
+REGISTER_KERNEL_BUILDER(                                        \
+    Name("FusedEmbeddingSparsePostLookUp")                      \
+    .Device(DEVICE_CPU),                                        \
+    FusedSafeEmbeddingPostLookupOp<CPUDevice>);
+
+
+template <typename Device>
+class FusedSafeEmbeddingPostLookupGradOp : public OpKernel {
+ public:
+  explicit FusedSafeEmbeddingPostLookupGradOp(OpKernelConstruction* ctx)
+      : OpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("num_partitions", &num_partitions_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("partition_axis", &partition_axis_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("combiner", &combiner_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("max_norm", &max_norm_));
+    int temp_default_id;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("default_id", &temp_default_id));
+    default_id_ = int64_t(temp_default_id);
+    if (combiner_ == "sum") {
+      operation_ = SparseSegmentReductionOperation::kSum;
+    } else if (combiner_ == "mean") {
+      operation_ = SparseSegmentReductionOperation::kMean;
+    } else if (combiner_ == "sqrtn") {
+      operation_ = SparseSegmentReductionOperation::kSqrtN;
+    } else {
+      OP_REQUIRES(ctx, false,
+          errors::InvalidArgument("Currently, 'mean', 'sqrtn' and 'sum' are only supported"));
+    }
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    Tensor const* top_grad_tensor = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->input("top_grad", &top_grad_tensor));
+
+    OpInputList emb_shards;
+    OP_REQUIRES_OK(ctx, ctx->input_list("emb_shards", &emb_shards));
+
+    OpInputList partitioned_indices;
+    OP_REQUIRES_OK(
+        ctx, ctx->input_list("partitioned_indices", &partitioned_indices));
+
+    Tensor const* feature_nums = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->input("feature_nums", &feature_nums));
+
+    Tensor const* row_empty_and_invalid_flags = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->input("row_empty_and_invalid_flags",
+                                   &row_empty_and_invalid_flags));
+
+    OpOutputList grad_shards;
+    OP_REQUIRES_OK(ctx, ctx->output_list("grad_shards", &grad_shards));
+
+    const float *top_grad = top_grad_tensor->flat<float>().data();
+    const int64_t batch_size = top_grad_tensor->shape().dim_size(0);
+    const int64_t emb_vec_size = emb_shards[0].shape().dim_size(1);
+    const int *f_nums = feature_nums->flat<int>().data();
+    const int *empty_row = row_empty_and_invalid_flags->flat<int>().data();
+
+    const bool set_empty_row_zero = default_id_ >= 0;
+
+    for (int i = 0; i < num_partitions_; i++) {
+      const int64_t sub_nnz = partitioned_indices[i].shape().dim_size(0);
+      const int64_t indices_col = partitioned_indices[i].shape().dim_size(1);
+      const int64 *indices = partitioned_indices[i].flat<int64>().data();
+      Tensor* grad_shard;
+      OP_REQUIRES_OK(
+          ctx, grad_shards.allocate(i, TensorShape({sub_nnz, emb_vec_size}),
+                                    &grad_shard));
+      float *grad = grad_shard->flat<float>().data();
+
+      std::vector<float> l2_norm(sub_nnz, 1.0);
+      if (max_norm_ > 0.0) {
+        const float *emb = emb_shards[i].flat<float>().data();
+        for (int j = 0; j < sub_nnz; ++j) {
+          float sum = 0.0;
+          for (int k = 0; k < emb_vec_size; ++k) {
+            sum += emb[j * emb_vec_size + k] * emb[j * emb_vec_size + k];
+          }
+          l2_norm[j] = std::sqrt(sum);
+        }
+      }
+
+      if (operation_ == SparseSegmentReductionOperation::kSum) {
+        for (int j = 0 ; j < sub_nnz; ++j) {
+          int64 idx = indices[j*indices_col];
+          if (set_empty_row_zero == true && empty_row[idx] == 1)
+            memset(&grad[j*emb_vec_size], 0, sizeof(float)*emb_vec_size);
+          else
+            memcpy(&grad[j*emb_vec_size], &top_grad[idx*emb_vec_size], sizeof(float)*emb_vec_size);
+        }
+      }
+      else if (operation_ == SparseSegmentReductionOperation::kMean) {
+        for (int j = 0 ; j < sub_nnz; ++j) {
+          int64 idx = indices[j*indices_col];
+          if (set_empty_row_zero == true && empty_row[idx] == 1)
+            memset(&grad[j*emb_vec_size], 0, sizeof(float)*emb_vec_size);
+          else {
+            for (int k = 0; k < emb_vec_size; ++k) {
+              grad[j*emb_vec_size + k] = top_grad[idx*emb_vec_size + k] / f_nums[idx];
+              if (l2_norm[j] > max_norm_) {
+                grad[j*emb_vec_size + k] *= max_norm_ / l2_norm[j];
+              }
+            }
+          }
+        }
+      }
+      else if (operation_ == SparseSegmentReductionOperation::kSqrtN) {
+        for (int j = 0 ; j < sub_nnz; ++j) {
+          int64 idx = indices[j*indices_col];
+          if (set_empty_row_zero == true && empty_row[idx] == 1)
+            memset(&grad[j*emb_vec_size], 0, sizeof(float)*emb_vec_size);
+          else {
+            for (int k = 0; k < emb_vec_size; ++k) {
+              grad[j*emb_vec_size + k] = top_grad[idx*emb_vec_size + k] / std::sqrt(f_nums[idx]);
+              if (l2_norm[j] > max_norm_) {
+                grad[j*emb_vec_size + k] *= max_norm_ / l2_norm[j];
+              }
+            }
+          }
+        }
+      }
+      else {
+        OP_REQUIRES(ctx, false,
+          errors::InvalidArgument("Currently, 'mean', 'sqrtn' and 'sum' are only supported"));
+      }
+    }
+  }
+
+private:
+  int num_partitions_;
+  int partition_axis_;
+  std::string combiner_;
+  float max_norm_;
+  int64_t default_id_;
+  SparseSegmentReductionOperation operation_;
+};
+
+REGISTER_KERNEL_BUILDER(                                        \
+    Name("FusedEmbeddingSparsePostLookUpGrad")                  \
+    .Device(DEVICE_CPU),                                        \
+    FusedSafeEmbeddingPostLookupGradOp<CPUDevice>);
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_op.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_op.cc
@@ -14,392 +14,156 @@ typedef Eigen::ThreadPoolDevice CPUDevice;
 enum SparseSegmentReductionOperation { kSum, kMean, kSqrtN };
 
 namespace {
-    // input: input tensor value (it sores the id)
-    // cols: How many elements to do SparseSegmentSum
-    // output: rows * embedding_size
-    template<typename T>
-    static void sparse_gather_v1(T *input, int rows, int cols,
-                                float *embedding_table, float *output,
-                                int embedding_size, bool is_mean) {
-      T *pidx = input;
-      for (int i = 0; i < rows; ++i) {
-        for (int j = 0; j < embedding_size; ++j) {
-          float value = 0;
-          int dense_num = 0;
-          for (int k = 0; k < cols; ++k) {
-            int embedding_row = (int)pidx[k];
-            if (embedding_row >= 0) {
-              value += embedding_table[embedding_row * embedding_size + j];
-              dense_num += 1;
-            }
+  inline int64 partitioned_indices(std::vector<std::tuple<size_t, const int64*>> &indices, int indice_dim, int64 id) {
+      int indices_num = indices.size();
+      int64 rows = 0;
+      for (int i = 0; i < indices_num; ++i) {
+          size_t sub_nnz = std::get<0>(indices[i]);
+          rows += sub_nnz;
+          if (rows > id) {
+              int idx = id - (rows - sub_nnz);
+              return std::get<1>(indices[i])[idx * indice_dim];
           }
+      }
+  }
 
-          if (is_mean && dense_num > 0) {
-              *output++ = value / dense_num;
-          } else {
-              *output++ = value;
+  inline const float* const partitioned_embedding_tables(std::vector<std::tuple<size_t, const float*>> &embedding_tables,
+                                                          int embedding_size, int64 id) {
+      int tables_num = embedding_tables.size();
+      int64 rows = 0;
+      for (int i = 0; i < tables_num; ++i) {
+          size_t sub_nnz = std::get<0>(embedding_tables[i]);
+          rows += sub_nnz;
+          if (rows > id) {
+              int idx = id - (rows - sub_nnz);
+              return &(std::get<1>(embedding_tables[i])[idx * embedding_size]);
           }
-        }
-        pidx += cols;
       }
-    }
+  }
 
-    // embedding_size = 1
-    template<typename T>
-    static void sparse_gather_embeddingsize1(T *input, int rows, int cols,
-                                            float *embedding_table, float *output,
-                                            bool is_mean) {
-    T *pidx = input;
-    for (int i = 0; i < rows; ++i) {
-      float value = 0;
-      int dense_num = 0;
-      for (int k = 0; k < cols; ++k) {
-        int embedding_row = pidx[k];
-        if (embedding_row >= 0) {
-            value += embedding_table[embedding_row];
-            dense_num += 1;
-        }
-      }
-      if (is_mean && dense_num > 0) {
-        *output++ = value / dense_num;
-      } else {
-        *output++ = value;
-      }
-      pidx += cols;
-    }
-    }
-
-    // input cols = 1
-    template<typename T>
-    static void sparse_gather_column1(T *input, int rows, float *embedding_table,
-                            float *output, int embedding_size) {
-    T *pidx = input;
-    for (int i = 0; i < rows; ++i) {
-        int embedding_row = *pidx++;
-        if (embedding_row >= 0) {
-        float *pembedding = &embedding_table[embedding_row * embedding_size];
-        for (int j = 0; j < embedding_size; ++j) {
-            output[j] = pembedding[j];
-        }
-        } else {
-        for (int j = 0; j < embedding_size; ++j) {
-            output[j] = 0;
-        }
-        }
-        output += embedding_size;
-    }
-    }
-
-    template<typename T>
-    static void sparse_gather(T *input, int rows, int cols, float *embedding_table,
-                            float *output, int embedding_size, bool is_mean) {
-      if (embedding_size == 1) {
-        sparse_gather_embeddingsize1(input, rows, cols, embedding_table, output,
-                                      is_mean);
-      } else if (cols == 1) {
-        sparse_gather_column1(input, rows, embedding_table, output, embedding_size);
-      } else {
-        //printf("General sparse gather!\n");
-        sparse_gather_v1(input, rows, cols, embedding_table, output, embedding_size,
-                        is_mean);
-      }
-    }
-
-    // Use memcpy or manually assign?
-    static void mycopy(float *dst, float *src, int float_num) {
-      memcpy(dst, src, float_num * sizeof(float));
-    }
-
-    static void myadd(float *dst, float *src, int float_num) {
-      for (int i = 0; i < float_num; ++i) {
-        dst[i] += src[i];
-      }
-    }
-
-    template<typename T>
-    static void row_add(std::map<T *, std::vector<const T *>> &mapSet, int64 row_nums) {
-
-      for (auto it = mapSet.begin(); it != mapSet.end(); ++it){
-        T * dst = it->first;
-        std::vector<const T *> srcs(std::move(it->second));
-        int64 src_size = srcs.size();
-
-        for (int row = 0; row < row_nums; ++row){
-          dst[row] = 0.0;
-          for (int index = 0; index < src_size; ++index) {
-            dst[row] += srcs[index][row];
-          }
-        }
-      }
-    }
-
-    template<typename T>
-    static void row_add_mean(std::map<T *, std::vector<const T *>> &mapSet, int64 row_nums, bool is_mean) {
-
-#define L(n) srcs[index + n][row]
-
-      for (auto it = mapSet.begin(); it != mapSet.end(); ++it){
-        T * dst = it->first;
-        std::vector<const T *> srcs(std::move(it->second));
-        int64 src_size = srcs.size();
-
-        if (src_size==1){
-          for (int row = 0; row < row_nums; ++row){
-            dst[row] = srcs[0][row];
-          }
-          continue;
-        }
-
-        float sum_tmp = 0.0;
-        int64 index = 0;
-        int64 r = (src_size) % 8;
-        int64 m = 1;
-        if (src_size < 10 && is_mean) m = src_size;
-
-        for (int row = 0; row < row_nums; ++row){
-          sum_tmp = 0.0;
-          index = 0;
-          dst[row] = 0.0;
-          switch (r) {
-            case 2: {
-              sum_tmp = (L(0) + L(1)) / m;
-              dst[row] = sum_tmp;
-              break;
-            }
-            case 3: {
-              sum_tmp = (L(0) + L(1) + L(2)) / m;
-              dst[row] = sum_tmp;
-              break;
-            }
-            case 4: {
-              sum_tmp = (L(0) + L(1) + L(2) + L(3)) / m;
-              dst[row] = sum_tmp;
-              break;
-            }
-            case 5: {
-              sum_tmp = (L(0) + L(1) + L(2) + L(3) + L(4)) / m;
-              dst[row] = sum_tmp;
-              break;
-            }
-            case 6: {
-              sum_tmp = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5)) / m;
-              dst[row] = sum_tmp;
-              break;
-            }
-            case 7: {
-              sum_tmp = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6)) / m;
-              dst[row] = sum_tmp;
-              break;
-            }
-            case 0: {
-              dst[row] = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6) + L(7)) / m;
-              index += 8;
-              break;
-            }
-            case 1: {
-              dst[row] = (L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6) + L(7) + L(8)) / m;
-              index += 8;
-              break;
-            }
-          }
-          for (index += r; index < src_size; index += 8) {
-            sum_tmp = L(0) + L(1) + L(2) + L(3) + L(4) + L(5) + L(6) + L(7);
-            dst[row] += sum_tmp;
-          }
-          if (src_size >= 10 && is_mean) dst[row] /= src_size;
-        }
-      }
-    }
-
-    static void myscale(float *dst, float factor, int float_num) {
-      for (int i = 0; i < float_num; ++i) {
-          dst[i] *= factor;
-      }
-    }
-
-    static void sparse_gather(int64 *input, int64 input_size, int64 *indice,
-                            int indice_dim, int64 *shape, int rows, int cols,
-                            float *embedding_table, float *output,
-                            int embedding_size, bool is_mean) {
-      // Record how many values in each row
-      int *row_values = new int[rows];
-      memset(row_values, 0, rows * sizeof(int));
-
-      std::map<float *, std::vector<const float *>> mapSet;
-
-      for (int64 i = 0; i < input_size; ++i) {
-        int64 id = input[i];
-        if (i < input_size && input[i] < 0) { // Skip invalid id
-          continue;
-        }
-        auto row = indice[i * indice_dim];
-        // for (int k = 1; k < indice_dim - 1; ++k) {
-        //   row = row * shape[k] + indice[i * indice_dim + k];
-        // }
-        row_values[row] += 1;
-
-        auto index = row * embedding_size;
-        if (!mapSet.count(&output[index])){
-          std::vector<const float *> srcs;
-          mapSet[&output[index]] = srcs;
-        }
-        mapSet[&output[index]].push_back(&embedding_table[id * embedding_size]);
-      }
-
-      // row_add(mapSet, embedding_size);
-      row_add_mean(mapSet, embedding_size, is_mean);
-
-      for (int i = 0; i < rows; ++i) {
-        if (row_values[i] == 0) {
-          memset(&output[i * embedding_size], 0, embedding_size * sizeof(float));
-        // } else if (is_mean && row_values[i] > 1) {
-        //   float factor = 1.0f / row_values[i];
-        //   myscale(&output[i * embedding_size], factor, embedding_size);
-        }
-      }
-      delete[] row_values;
-    }
-
-    inline int64 partitioned_indices(std::vector<std::tuple<size_t, const int64*>> &indices, int indice_dim, int64 id) {
-        int indices_num = indices.size();
-        int64 rows = 0;
-        for (int i = 0; i < indices_num; ++i) {
-            size_t sub_nnz = std::get<0>(indices[i]);
-            rows += sub_nnz;
-            if (rows > id) {
-                int idx = id - (rows - sub_nnz);
-                return std::get<1>(indices[i])[idx * indice_dim];
-            }
-        }
-    }
-
-    inline const float* const partitioned_embedding_tables(std::vector<std::tuple<size_t, const float*>> &embedding_tables,
-                                                           int embedding_size, int64 id) {
-        int tables_num = embedding_tables.size();
-        int64 rows = 0;
-        for (int i = 0; i < tables_num; ++i) {
-            size_t sub_nnz = std::get<0>(embedding_tables[i]);
-            rows += sub_nnz;
-            if (rows > id) {
-                int idx = id - (rows - sub_nnz);
-                return &(std::get<1>(embedding_tables[i])[idx * embedding_size]);
-            }
-        }
-    }
-
-    static void sparse_partitioned_gather(int64 input_size,
-                            std::vector<std::tuple<size_t, const int64*>> &indices, int indice_dim, int rows,
-                            std::vector<std::tuple<size_t, const float*>> &embedding_tables, float *output,
-                            const int64_t embedding_size, SparseSegmentReductionOperation operation,
-                            const bool set_empty_row_zero, const int *empty_row) {
-      // Record how many values in each row
-      uint64_t* row_values = new uint64_t[rows];
-      memset(row_values, 0, rows * sizeof(uint64_t));
-      // output_buffer is output buffer
-      float* output_buffer = new float[rows*embedding_size];
-      memset(output_buffer, 0, rows*embedding_size * sizeof(float));
+  static void sparse_partitioned_gather(int64 input_size,
+                          std::vector<std::tuple<size_t, const int64*>> &indices, int indice_dim, int rows,
+                          std::vector<std::tuple<size_t, const float*>> &embedding_tables, float *output,
+                          const int64_t embedding_size, SparseSegmentReductionOperation operation,
+                          const bool set_empty_row_zero, const int *empty_row) {
+    // Record how many values in each row
+    uint64_t* row_values = new uint64_t[rows];
+    memset(row_values, 0, rows * sizeof(uint64_t));
+    // output_buffer is output buffer
+    float* output_buffer = new float[rows*embedding_size];
+    memset(output_buffer, 0, rows*embedding_size * sizeof(float));
 
 #ifdef __AVX512F__
-      auto avx512_add = [](const float* input, uint64_t input_idx,
-                           float* output, uint64_t output_idx, const int64_t num) {
-        constexpr size_t float_displacement = 4;
-        constexpr size_t float_alignment = 16;
-        int64_t quotient = num >> float_displacement;
-        int64_t remainder = num & 0x000F;
+    auto avx512_add = [](const float* input, uint64_t input_idx,
+                          float* output, uint64_t output_idx, const int64_t num) {
+      constexpr size_t float_displacement = 4;
+      constexpr size_t float_alignment = 16;
+      int64_t quotient = num >> float_displacement;
+      int64_t remainder = num & 0x000F;
 
-        for (int64_t j = 0; j < quotient; ++j) {
-          int64_t offset = j << float_displacement;
-          __m512 a = _mm512_loadu_ps(&input[input_idx + offset]);
-          __m512 b = _mm512_loadu_ps(&output[output_idx + offset]);
-          a = _mm512_add_ps(a, b);
-          _mm512_storeu_ps(&output[output_idx + offset], a);
-        }
+      for (int64_t j = 0; j < quotient; ++j) {
+        int64_t offset = j << float_displacement;
+        __m512 a = _mm512_loadu_ps(&input[input_idx + offset]);
+        __m512 b = _mm512_loadu_ps(&output[output_idx + offset]);
+        a = _mm512_add_ps(a, b);
+        _mm512_storeu_ps(&output[output_idx + offset], a);
+      }
 
-        if (remainder != 0) {
-          __mmask16 mask = 0xffff >> (float_alignment - remainder);
-          int64_t offset = quotient << float_displacement;
-          __m512 a = _mm512_mask_loadu_ps(_mm512_setzero_ps(), mask, &input[input_idx + offset]);
-          __m512 b = _mm512_mask_loadu_ps(_mm512_setzero_ps(), mask, &output[output_idx + offset]);
-          a = _mm512_mask_add_ps(_mm512_setzero_ps(), mask, a, b);
-          _mm512_mask_storeu_ps(&output[output_idx + offset], mask, a);
-        }
-      };
+      if (remainder != 0) {
+        __mmask16 mask = 0xffff >> (float_alignment - remainder);
+        int64_t offset = quotient << float_displacement;
+        __m512 a = _mm512_mask_loadu_ps(_mm512_setzero_ps(), mask, &input[input_idx + offset]);
+        __m512 b = _mm512_mask_loadu_ps(_mm512_setzero_ps(), mask, &output[output_idx + offset]);
+        a = _mm512_mask_add_ps(_mm512_setzero_ps(), mask, a, b);
+        _mm512_mask_storeu_ps(&output[output_idx + offset], mask, a);
+      }
+    };
 
-      auto avx512_add_mean = [](const float* input, uint64_t input_idx, const float* sum,
-                                float* output, uint64_t output_idx, const int64_t num) {
-        constexpr size_t float_displacement = 4;
-        constexpr size_t float_alignment = 16;
-        int64_t quotient = num >> float_displacement;
-        int64_t remainder = num & 0x000F;
-        __m512 sum_ = _mm512_broadcastss_ps(_mm_load_ss(sum));
+    auto avx512_mean = [](const float* input, uint64_t input_idx, const float* sum,
+                              float* output, uint64_t output_idx, const int64_t num) {
+      constexpr size_t float_displacement = 4;
+      constexpr size_t float_alignment = 16;
+      int64_t quotient = num >> float_displacement;
+      int64_t remainder = num & 0x000F;
+      __m512 sum_ = _mm512_broadcastss_ps(_mm_load_ss(sum));
 
-        for (int64_t j = 0; j < quotient; ++j) {
-          int64_t offset = j << float_displacement;
-          __m512 a = _mm512_loadu_ps(&input[input_idx + offset]);
-          __m512 b = _mm512_loadu_ps(&output[output_idx + offset]);
-          a = _mm512_add_ps(a, b);
-          a = _mm512_div_ps(a, sum_);
-          _mm512_storeu_ps(&output[output_idx + offset], a);
-        }
+      for (int64_t j = 0; j < quotient; ++j) {
+        int64_t offset = j << float_displacement;
+        __m512 a = _mm512_loadu_ps(&input[input_idx + offset]);
+        __m512 b = _mm512_loadu_ps(&output[output_idx + offset]);
+        a = _mm512_add_ps(a, b);
+        a = _mm512_div_ps(a, sum_);
+        _mm512_storeu_ps(&output[output_idx + offset], a);
+      }
 
-        if (remainder != 0) {
-          __mmask16 mask = 0xffff >> (float_alignment - remainder);
-          int64_t offset = quotient << float_displacement;
-          __m512 a = _mm512_mask_loadu_ps(_mm512_setzero_ps(), mask, &input[input_idx + offset]);
-          __m512 b = _mm512_mask_loadu_ps(_mm512_setzero_ps(), mask, &output[output_idx + offset]);
-          a = _mm512_mask_add_ps(_mm512_setzero_ps(), mask, a, b);
-          a = _mm512_mask_div_ps(_mm512_setzero_ps(), mask, a, sum_);
-          _mm512_mask_storeu_ps(&output[output_idx + offset], mask, a);
-        }
-      };
+      if (remainder != 0) {
+        __mmask16 mask = 0xffff >> (float_alignment - remainder);
+        int64_t offset = quotient << float_displacement;
+        __m512 a = _mm512_mask_loadu_ps(_mm512_setzero_ps(), mask, &input[input_idx + offset]);
+        __m512 b = _mm512_mask_loadu_ps(_mm512_setzero_ps(), mask, &output[output_idx + offset]);
+        a = _mm512_mask_add_ps(_mm512_setzero_ps(), mask, a, b);
+        a = _mm512_mask_div_ps(_mm512_setzero_ps(), mask, a, sum_);
+        _mm512_mask_storeu_ps(&output[output_idx + offset], mask, a);
+      }
+    };
 #endif
 
-      for (int64_t i = input_size-1; i >= 0; --i) {
-        // From sub_indices to find output row
-        auto row = partitioned_indices(indices, indice_dim, i);
-        row_values[row] += 1;
-        // From sub_embedding_tables to find embedding_table row ptr
-        auto embedding_row = partitioned_embedding_tables(embedding_tables, embedding_size, i);
-        // add output_buffer to do block addition
-        uint64_t output_row = row * embedding_size;
+    for (int64_t i = input_size-1; i >= 0; --i) {
+      // From sub_indices to find output row
+      auto row = partitioned_indices(indices, indice_dim, i);
+      row_values[row] += 1;
+      // From sub_embedding_tables to find embedding_table row ptr
+      auto embedding_row = partitioned_embedding_tables(embedding_tables, embedding_size, i);
+      // add output_buffer to do block addition
+      uint64_t output_row = row * embedding_size;
 
 #ifdef __AVX512F__
-        avx512_add(embedding_row, 0, output_buffer, output_row, embedding_size);
+      avx512_add(embedding_row, 0, output_buffer, output_row, embedding_size);
+#else
+      for (int64_t j = 0; j < embedding_size; ++j) {
+        output_buffer[output_row + j] += embedding_row[j];
+      }
+#endif
+
+      if (row_values[row] == 8) {
+        memcpy(&output[output_row], &output_buffer[output_row], embedding_size * sizeof(float));
+        memset(&output_buffer[output_row], 0, embedding_size * sizeof(float));
+      }
+      else if (row_values[row] % 8 == 0) {
+#ifdef __AVX512F__
+        avx512_add(output_buffer, output_row, output, output_row, embedding_size);
 #else
         for (int64_t j = 0; j < embedding_size; ++j) {
-          output_buffer[output_row + j] += embedding_row[j];
+          output[output_row + j] += output_buffer[output_row + j];
         }
 #endif
-
-        if (row_values[row] == 8) {
-          memcpy(&output[output_row], &output_buffer[output_row], embedding_size * sizeof(float));
-          memset(&output_buffer[output_row], 0, embedding_size * sizeof(float));
-        }
-        else if (row_values[row] % 8 == 0) {
-#ifdef __AVX512F__
-          avx512_add(output_buffer, output_row, output, output_row, embedding_size);
-#else
-          for (int64_t j = 0; j < embedding_size; ++j) {
-            output[output_row + j] += output_buffer[output_row + j];
-          }
-#endif
-          memset(&output_buffer[output_row], 0, embedding_size * sizeof(float));
-        }
+        memset(&output_buffer[output_row], 0, embedding_size * sizeof(float));
       }
+    }
 
-      for (uint64_t i = 0; i < rows; ++i) {
-        uint64_t output_row = i * embedding_size;
+    for (int64_t i = 0; i < rows; ++i) {
+      int64_t output_row = i * embedding_size;
+      // zero emtpy rows
+      if (set_empty_row_zero && empty_row[i] == 1) {
+        memset(&output[output_row], 0, embedding_size * sizeof(float));
+      }
+      else {
 #ifdef __AVX512F__
         if (operation == SparseSegmentReductionOperation::kSum) {
-          avx512_add(output_buffer, output_row, output, output_row, embedding_size);
+          if (row_values[i] < 8) {
+            memcpy(&output[output_row], &output_buffer[output_row], embedding_size * sizeof(float));
+          }
+          else {
+            avx512_add(output_buffer, output_row, output, output_row, embedding_size);
+          }
         }
         else if (operation == SparseSegmentReductionOperation::kMean) {
           float sum = static_cast<float>(row_values[i]);
-          avx512_add_mean(output_buffer, output_row, &sum, output, output_row, embedding_size);
+          avx512_mean(output_buffer, output_row, &sum, output, output_row, embedding_size);
         }
         else if (operation == SparseSegmentReductionOperation::kSqrtN) {
           float sqrt = std::sqrt(row_values[i]);
-          avx512_add_mean(output_buffer, output_row, &sqrt, output, output_row, embedding_size);
+          avx512_mean(output_buffer, output_row, &sqrt, output, output_row, embedding_size);
         }
 #else
         if (operation == SparseSegmentReductionOperation::kSum) {
@@ -421,27 +185,19 @@ namespace {
         }
 #endif
       }
-
-      for (int64_t i = 0; i < rows; ++i) {
-        // zero emtpy rows
-        if (set_empty_row_zero && empty_row[i] == 1) {
-            memset(&output[i * embedding_size], 0, embedding_size * sizeof(float));
-        }
-      }
-
-      delete[] row_values;
-      delete[] output_buffer;
     }
 
-    static void set_feature_nums(int32 *feature_nums, int64 input_size,
-                                 std::vector<std::tuple<size_t, const int64*>> indices, int indice_dim) {
-        for (int64 i = 0; i < input_size; ++i) {
-            feature_nums[partitioned_indices(indices, indice_dim, i)]++;
-        }
+    delete[] row_values;
+    delete[] output_buffer;
+  }
+
+  static inline void set_feature_nums(int32 *feature_nums, int64 input_size,
+                                std::vector<std::tuple<size_t, const int64*>> indices, int indice_dim) {
+    for (int64 i = 0; i < input_size; ++i) {
+        feature_nums[partitioned_indices(indices, indice_dim, i)]++;
     }
+  }
 }
-
-
 
 template <typename Device>
 class FusedSafeEmbeddingPostLookupOp : public OpKernel {

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_op_test.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_op_test.cc
@@ -1,0 +1,279 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/platform/test_benchmark.h"
+#include "tensorflow/core/public/session.h"
+
+namespace tensorflow {
+namespace {
+
+enum class Device { CPU, GPU };
+class FusedSafeEmbeddingPostLookupOpTest : public OpsTestBase {
+ protected:
+  void MakeOpAndSetDevice(Device device, int num_partitions, DataType dtype,
+                          const std::string& combiner, const float max_norm,
+                          const int default_id) {
+    if (device == Device::GPU) {
+      SetDevice(DEVICE_GPU,
+                std::unique_ptr<tensorflow::Device>(DeviceFactory::NewDevice(
+                    "GPU", {}, "/job:a/replica:0/task:0")));
+    }
+
+    TF_EXPECT_OK(NodeDefBuilder("fused_safe_embedding_post_look_up",
+                                "FusedEmbeddingSparsePostLookUp")
+                     .Attr("T", dtype)
+                     .Attr("num_partitions", num_partitions)
+                     .Attr("partition_axis", 0)
+                     .Attr("combiner", combiner)
+                     .Attr("max_norm", max_norm)
+                     .Attr("default_id", default_id)
+                     .Input(FakeInput(num_partitions, dtype))
+                     .Input(FakeInput(num_partitions, DT_INT64))
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(DT_INT32))
+                     .Input(FakeInput(DT_INT64))
+                     .Finalize(node_def()));
+    TF_EXPECT_OK(InitOp());
+  }
+};
+
+// TEST_F(FusedSafeEmbeddingPostLookupOpTest,
+//        Partition3_Sqrtn_MaxNorm200_Float) {
+//   const int nnz = 10;
+//   const int batch_size = 4;
+//   const int emb_vector_dim = 8;
+//   const int entries = 8;
+
+//   MakeOpAndSetDevice(Device::CPU, 3, DT_FLOAT, "sqrtn", 200.0, -1);
+
+//   // emb_shards
+//   AddInputFromArray<float>(
+//       TensorShape({6, emb_vector_dim}),
+//       {
+//           8.0,  9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 24.0, 25.0,
+//           26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 24.0, 25.0, 26.0, 27.0,
+//           28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0,
+//           38.0, 39.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0,
+//           40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0,
+//       });
+//   AddInputFromArray<float>(TensorShape({1, emb_vector_dim}),
+//                            {56.0, 57.0, 58.0, 59.0, 60.0, 61.0, 62.0, 63.0});
+//   AddInputFromArray<float>(
+//       TensorShape({3, emb_vector_dim}),
+//       {96.0,  97.0,  98.0,  99.0,  100.0, 101.0, 102.0, 103.0,
+//        96.0,  97.0,  98.0,  99.0,  100.0, 101.0, 102.0, 103.0,
+//        120.0, 121.0, 122.0, 123.0, 124.0, 125.0, 126.0, 127.0});
+
+//   // partitioned_indices
+//   AddInputFromArray<int64>(TensorShape({6, 2}),
+//                            {0, 5, 0, 1, 2, 1, 1, 2, 3, 6, 1, 1});
+//   AddInputFromArray<int64>(TensorShape({1, 2}), {1, 7});
+//   AddInputFromArray<int64>(TensorShape({3, 2}), {2, 4, 2, 7, 3, 0});
+
+//   // sp_dense_shape
+//   AddInputFromArray<int64>(TensorShape({2}), {batch_size, entries});
+
+//   // row_empty_and_invalid_flags
+//   AddInputFromArray<int>(TensorShape({batch_size + nnz}),
+//                          {0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+
+//   TF_ASSERT_OK(RunOpKernel());
+//   TF_EXPECT_OK(device_->Sync());
+
+//   {
+//     Tensor expected_emb_vectors(allocator(), DT_FLOAT,
+//                                 TensorShape({batch_size, emb_vector_dim}));
+//     test::FillValues<float>(
+//         &expected_emb_vectors,
+//         {22.62741661, 24.04163170, 25.45584488,  26.87005806,  28.28427124,
+//          29.69848442, 31.11269951, 32.52691269,  73.90083313,  75.63288879,
+//          77.36493683, 79.09698486, 80.82904053,  82.56108856,  84.29314423,
+//          86.02519226, 92.61308289, 94.01081848,  95.40855408,  96.80628204,
+//          98.20401764, 99.60175323, 100.99948120, 102.39721680, 71.20205688,
+//          72.31395721, 73.42584991, 74.53774261,  75.64963531,  76.76153564,
+//          77.87342834, 78.98532867});
+//     test::ExpectTensorNear<float>(expected_emb_vectors, *GetOutput(0), 1e-4);
+//   }
+//   {
+//     Tensor feature_nums_expected(allocator(), DT_INT32,
+//                                  TensorShape({batch_size}));
+//     test::FillValues<int>(&feature_nums_expected, {2, 3, 3, 2});
+//     test::ExpectTensorEqual<int32>(feature_nums_expected, *GetOutput(1));
+//   }
+// }
+
+TEST_F(FusedSafeEmbeddingPostLookupOpTest,
+       Partition3_Sqrtn_Float) {
+  const int nnz = 10;
+  const int batch_size = 4;
+  const int emb_vector_dim = 8;
+  const int entries = 8;
+
+  MakeOpAndSetDevice(Device::CPU, 3, DT_FLOAT, "sqrtn", -1.0, -1);
+
+  // emb_shards
+  AddInputFromArray<float>(
+      TensorShape({6, emb_vector_dim}),
+      {
+          8.0,  9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 24.0, 25.0,
+          26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 24.0, 25.0, 26.0, 27.0,
+          28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0,
+          38.0, 39.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0,
+          40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0,
+      });
+  AddInputFromArray<float>(TensorShape({1, emb_vector_dim}),
+                           {56.0, 57.0, 58.0, 59.0, 60.0, 61.0, 62.0, 63.0});
+  AddInputFromArray<float>(
+      TensorShape({3, emb_vector_dim}),
+      {96.0,  97.0,  98.0,  99.0,  100.0, 101.0, 102.0, 103.0,
+       96.0,  97.0,  98.0,  99.0,  100.0, 101.0, 102.0, 103.0,
+       120.0, 121.0, 122.0, 123.0, 124.0, 125.0, 126.0, 127.0});
+
+  // partitioned_indices
+  AddInputFromArray<int64>(TensorShape({6, 2}),
+                           {0, 5, 0, 1, 2, 1, 1, 2, 3, 6, 1, 1});
+  AddInputFromArray<int64>(TensorShape({1, 2}), {1, 7});
+  AddInputFromArray<int64>(TensorShape({3, 2}), {2, 4, 2, 7, 3, 0});
+
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {batch_size, entries});
+
+  // row_empty_and_invalid_flags
+  AddInputFromArray<int>(TensorShape({batch_size + nnz}),
+                         {0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+
+  {
+    Tensor expected_emb_vectors(allocator(), DT_FLOAT,
+                                TensorShape({batch_size, emb_vector_dim}));
+    test::FillValues<float>(
+        &expected_emb_vectors,
+        {22.62741661, 24.04162979, 25.45584297, 26.87005806,
+         28.28427124, 29.69848442, 31.11269760, 32.52691269,
+         73.90083313, 75.63288116, 77.36493683, 79.09698486,
+         80.82903290, 82.56108856, 84.29313660, 86.02519226,
+         124.70765686, 126.43970490, 128.17175293, 129.90380859,
+         131.63586426, 133.36790466, 135.09996033, 136.83201599,
+         107.48023224, 108.89443970, 110.30865479, 111.72286987,
+         113.13708496, 114.55130005, 115.96550751, 117.37972260});
+    test::ExpectTensorNear<float>(expected_emb_vectors, *GetOutput(0), 1e-4);
+  }
+  {
+    Tensor feature_nums_expected(allocator(), DT_INT32,
+                                 TensorShape({batch_size}));
+    test::FillValues<int>(&feature_nums_expected, {2, 3, 3, 2});
+    test::ExpectTensorEqual<int32>(feature_nums_expected, *GetOutput(1));
+  }
+}
+
+TEST_F(FusedSafeEmbeddingPostLookupOpTest, Partition2_Sum_No_Default) {
+  const int nnz = 3;
+  const int batch_size = 3;
+  const int emb_vector_dim = 4;
+  const int entries = 8;
+
+  MakeOpAndSetDevice(Device::CPU, 2, DT_FLOAT, "sum", -1.0, -1);
+
+  // emb_shards
+  AddInputFromArray<float>(TensorShape({2, emb_vector_dim}),
+                           {1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0});
+  AddInputFromArray<float>(TensorShape({2, emb_vector_dim}),
+                           {10.0, 10.0, 10.0, 10.0, 13.0, 13.0, 13.0, 13.0});
+
+  // partitioned_indices
+  AddInputFromArray<int64>(TensorShape({2, 2}), {0, 0, 0, 5});
+  AddInputFromArray<int64>(TensorShape({2, 2}), {1, 4, 2, 0});
+
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {batch_size, entries});
+
+  // row_empty_and_invalid_flags
+  AddInputFromArray<int>(TensorShape({batch_size + nnz}), {0, 0, 1, 1, 1, 1});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+
+  {
+    Tensor expected_emb_vectors(allocator(), DT_FLOAT,
+                                TensorShape({batch_size, emb_vector_dim}));
+    test::FillValues<float>(
+        &expected_emb_vectors,
+        {3.0, 3.0, 3.0, 3.0, 10.0, 10.0, 10.0, 10.0, 13.0, 13.0, 13.0, 13.0});
+    test::ExpectTensorNear<float>(expected_emb_vectors, *GetOutput(0), 1e-4);
+  }
+  {
+    Tensor feature_nums_expected(allocator(), DT_INT32,
+                                 TensorShape({batch_size}));
+    test::FillValues<int>(&feature_nums_expected, {2, 1, 1});
+    test::ExpectTensorEqual<int32>(feature_nums_expected, *GetOutput(1));
+  }
+}
+
+TEST_F(FusedSafeEmbeddingPostLookupOpTest, Partition2_Sum_Default_0) {
+  const int nnz = 3;
+  const int batch_size = 3;
+  const int emb_vector_dim = 4;
+  const int entries = 8;
+
+  MakeOpAndSetDevice(Device::CPU, 2, DT_FLOAT, "sum", -1.0, 0);
+
+  // emb_shards
+  AddInputFromArray<float>(TensorShape({2, emb_vector_dim}),
+                           {1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0});
+  AddInputFromArray<float>(TensorShape({2, emb_vector_dim}),
+                           {10.0, 10.0, 10.0, 10.0, 13.0, 13.0, 13.0, 13.0});
+
+  // partitioned_indices
+  AddInputFromArray<int64>(TensorShape({2, 2}), {0, 0, 0, 5});
+  AddInputFromArray<int64>(TensorShape({2, 2}), {1, 4, 2, 0});
+
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {batch_size, entries});
+
+  // row_empty_and_invalid_flags
+  AddInputFromArray<int>(TensorShape({batch_size + nnz}), {0, 0, 1, 1, 1, 1});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+
+  {
+    Tensor expected_emb_vectors(allocator(), DT_FLOAT,
+                                TensorShape({batch_size, emb_vector_dim}));
+    test::FillValues<float>(
+        &expected_emb_vectors,
+        {3.0, 3.0, 3.0, 3.0, 10.0, 10.0, 10.0, 10.0, 0.0, 0.0, 0.0, 0.0});
+    test::ExpectTensorNear<float>(expected_emb_vectors, *GetOutput(0), 1e-4);
+  }
+  {
+    Tensor feature_nums_expected(allocator(), DT_INT32,
+                                 TensorShape({batch_size}));
+    test::FillValues<int>(&feature_nums_expected, {2, 1, 1});
+    test::ExpectTensorEqual<int32>(feature_nums_expected, *GetOutput(1));
+  }
+}
+
+}  // namespace
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_op_test.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_post_op_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/platform/test_benchmark.h"
 #include "tensorflow/core/public/session.h"
+#include "tensorflow/cc/ops/standard_ops.h"
 
 namespace tensorflow {
 namespace {
@@ -274,6 +275,139 @@ TEST_F(FusedSafeEmbeddingPostLookupOpTest, Partition2_Sum_Default_0) {
     test::ExpectTensorEqual<int32>(feature_nums_expected, *GetOutput(1));
   }
 }
+
+
+//----------------------------------------------------------------------------//
+// Performance benchmarks                                                     //
+//----------------------------------------------------------------------------//
+
+template <typename T>
+void FillValues(Tensor* tensor, gtl::ArraySlice<T> vals) {
+  auto flat = tensor->flat<T>();
+  CHECK_EQ(flat.size(), vals.size());
+  if (flat.size() > 0) {
+    std::copy_n(vals.data(), vals.size(), flat.data());
+  }
+}
+
+template <typename T>
+void FillZerosValues(Tensor* tensor) {
+  auto flat = tensor->flat<T>();
+  for (int i = 0; i < flat.size(); ++i) {
+    flat.data()[i] = 0.0;
+  }
+}
+
+template <typename T>
+void FillOnesValues(Tensor* tensor) {
+  auto flat = tensor->flat<T>();
+  float scale = std::rand()/((RAND_MAX + 1u)/6);
+  for (int i = 0; i < flat.size(); ++i) {
+    flat.data()[i] = 1.1 * scale;
+  }
+}
+
+template <typename T>
+void FillIndiceValues(Tensor* tensor, const int partitions, const int batch_size, const int entries) {
+  auto flat = tensor->flat<T>();
+  int k = 0;
+  for (int i = 0; i < batch_size; ++i) {
+    for (int j = 0; j < entries; ++j) {
+      flat.data()[k] = i + partitions;
+      flat.data()[k+1] = j;
+      k += 2;
+    }
+  }
+}
+
+template <typename T>
+void PrintValues(Tensor* tensor) {
+  auto flat = tensor->flat<T>();
+  for (int i = 0; i < flat.size(); ++i) {
+    std::cout << flat.data()[i] << ", ";
+  }
+  std::cout << std::endl;
+}
+
+template <typename T>
+static Graph* EmbPostOp(const string& kind, int num_partitions, const std::string& combiner,
+                      const float max_norm, const int default_id) {
+  const int nnz = 3;
+  const int batch_size = 512;
+  const int emb_vector_dim = 32;
+  const int entries = 8;
+  const float sparsity = 0.5;
+  const int total_inputs = batch_size*entries*sparsity;
+
+  Graph* g = new Graph(OpRegistry::Global());
+  DataType type = DataTypeToEnum<T>::v();
+
+  const bool isDefault = (kind == "Default");
+  string op_name = isDefault ? "FusedEmbeddingSparsePostLookUpOrigin" : "FusedEmbeddingSparsePostLookUp";
+
+  // emb_shards
+  std::vector<NodeBuilder::NodeOut> input_emb_shards;
+  input_emb_shards.reserve(num_partitions);
+  for (int i = 0; i < num_partitions; ++i) {
+    Tensor emb_shards(type, TensorShape({total_inputs/num_partitions, emb_vector_dim}));
+    FillOnesValues<T>(&emb_shards);
+    input_emb_shards.push_back(test::graph::Constant(g, emb_shards));
+    // PrintValues<T>(&emb_shards);
+  }
+
+  // partitioned_indices
+  std::vector<NodeBuilder::NodeOut> partitioned_indices;
+  partitioned_indices.reserve(num_partitions);
+  for (int i = 0; i < num_partitions; ++i) {
+    Tensor sub_partitioned_indice(DT_INT64, TensorShape({total_inputs/num_partitions, 2}));
+    FillIndiceValues<int64>(&sub_partitioned_indice, i, batch_size/num_partitions, entries*sparsity);
+    partitioned_indices.push_back(test::graph::Constant(g, sub_partitioned_indice));
+    // PrintValues<int64>(&sub_partitioned_indice);
+  }
+
+  // sp_dense_shape
+  Tensor sp_dense_shape(DT_INT64, TensorShape({2}));
+  FillValues<int64>(&sp_dense_shape, {batch_size, entries});
+
+  // row_empty_and_invalid_flags
+  Tensor row_empty_and_invalid_flags(DT_INT32, TensorShape({batch_size + nnz}));
+  FillZerosValues<int>(&row_empty_and_invalid_flags);
+
+  auto nodeBuilder = NodeBuilder(g->NewName("n"), op_name)
+                    .Attr("T", type)
+                    .Attr("num_partitions", num_partitions)
+                    .Attr("partition_axis", 0)
+                    .Attr("combiner", combiner)
+                    .Attr("max_norm", max_norm)
+                    .Attr("default_id", default_id)
+                    .Input(input_emb_shards)
+                    .Input(partitioned_indices)
+                    .Input(test::graph::Constant(g, sp_dense_shape))
+                    .Input(test::graph::Constant(g, row_empty_and_invalid_flags))
+                    .Input(partitioned_indices);
+  TF_CHECK_OK(nodeBuilder.Finalize(g, nullptr));
+  return g;
+}
+
+#define BM_EMB_POST_OP(kind, NP, C, T, DEVICE, NTH)                                    \
+  static void BM_EMB_POST_OP##_##kind##_##NP##_##C##_##T##_##DEVICE##_##NTH(           \
+      int iters) {                                                                     \
+    testing::UseRealTime();                                                            \
+    SessionOptions opts;                                                               \
+    opts.config.set_intra_op_parallelism_threads(NTH);                                 \
+    test::Benchmark(#DEVICE, EmbPostOp<T>(#kind, NP, #C, -1.0, -1), &opts).Run(iters); \
+  }                                                                                    \
+  BENCHMARK(BM_EMB_POST_OP##_##kind##_##NP##_##C##_##T##_##DEVICE##_##NTH);            \
+
+#define BM_EMB_POST_OP_kind(NP, C, NTH)            \
+  BM_EMB_POST_OP(OPT, NP, C, float, CPU, NTH);     \
+
+#define BM_EMB_POST_OP_NTH(NP, C) \
+  BM_EMB_POST_OP_kind(NP, C, 1);  \
+  BM_EMB_POST_OP_kind(NP, C, 4);  \
+  BM_EMB_POST_OP_kind(NP, C, 8);  \
+
+BM_EMB_POST_OP_NTH(2, sum);
 
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_pre_op.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_pre_op.cc
@@ -62,6 +62,10 @@ class FusedEmbeddingSparsePreLookUpCPU : public OpKernel {
       partition_total_sizes_ += shape.flat<int64>().data()[0];
     }
 
+    // fixme(marvin): show error info when got fake input.
+    OP_REQUIRES(ctx, partition_total_sizes_ != 1,
+        errors::InvalidArgument("Not support EV yet"));
+
     // 1.1 define output tensors
     OpOutputList partitioned_values;
     OP_REQUIRES_OK(ctx,

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_pre_op.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_pre_op.cc
@@ -1,0 +1,202 @@
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/resource_mgr.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/resource_var.h"
+#include "tensorflow/core/framework/bounds_check.h"
+
+namespace tensorflow {
+
+struct IndicePair {
+  int64_t row;
+  int64_t column;
+};
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+class FusedEmbeddingSparsePreLookUpCPU : public OpKernel {
+ public:
+  explicit FusedEmbeddingSparsePreLookUpCPU(OpKernelConstruction* ctx)
+      : OpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("num_partitions", &num_partitions_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("partition_strategy", &partition_strategy_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("partition_axis", &partition_axis_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("fill_empty_row", &fill_empty_row_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("prune_invalid_id", &prune_invalid_id_));
+    int temp_default_id;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("default_id", &temp_default_id));
+    default_id_ = int64_t(temp_default_id);
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+
+    const int64_t default_id = default_id_ >= 0 ? default_id_ : 0;
+    // 1. get input tensor
+    Tensor const* values_tensor = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->input("sp_values", &values_tensor));
+    const int64_t nnz = values_tensor->shape().dim_size(0);
+
+    const int64_t* values = reinterpret_cast<const int64_t*>(
+                                  values_tensor->flat<int64>().data());
+
+    Tensor const* indices_tensor = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->input("sp_indices", &indices_tensor));
+
+    const IndicePair* indices = reinterpret_cast<const IndicePair*>(
+                                  indices_tensor->flat<int64>().data());
+
+    Tensor const* dense_shape = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->input("sp_dense_shape", &dense_shape));
+    const int64_t batch_size = dense_shape->flat<int64>().data()[0];
+
+    OpInputList partition_shapes;
+    OP_REQUIRES_OK(ctx, ctx->input_list("partition_shapes", &partition_shapes));
+
+    partition_total_sizes_ = 0;
+    for (const Tensor& shape : partition_shapes) {
+      OP_REQUIRES(ctx, shape.dims() <= 2,
+                  errors::InvalidArgument(
+                      "input partition_shapes must all less than rank 2"));
+      partition_total_sizes_ += shape.flat<int64>().data()[0];
+    }
+
+    // 1.1 define output tensors
+    OpOutputList partitioned_values;
+    OP_REQUIRES_OK(ctx,
+                   ctx->output_list("partitioned_values", &partitioned_values));
+    OpOutputList partitioned_indices;
+    OP_REQUIRES_OK(
+        ctx, ctx->output_list("partitioned_indices", &partitioned_indices));
+
+    Tensor* all_flags;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_output(2 * num_partitions_,
+                                  TensorShape{batch_size + nnz}, &all_flags));
+    int32_t* all_flags_list = all_flags->flat<int32_t>().data();
+
+    memset(all_flags_list, 0, (batch_size + nnz) * sizeof(int32_t));
+
+    // 2.1 get index
+    std::set<int64_t> indices_set;
+    std::vector<std::vector<IndicePair>> new_index_(num_partitions_, std::vector<IndicePair>(0));
+
+    std::vector<IndicePair> fill_empty_row_index_;
+    int64_t fill_empty_row_p_seg_ = 0;
+    int64_t fill_empty_row_p_val_ = 0;
+
+    int64_t p_seg = 0;
+    int64_t p_val = 0;
+    int64_t tmp_value = 0;
+    const int64_t ids_per_partition = partition_total_sizes_ / num_partitions_;
+    const int64_t extras = partition_total_sizes_ % num_partitions_;
+
+    // 2.2 get the map of the mutli-table index
+    for (int64_t origin_index = 0; origin_index < nnz; ++origin_index) {
+      tmp_value = values[origin_index];
+      if (tmp_value < 0){
+        all_flags_list[batch_size + origin_index] = 0;
+        if(prune_invalid_id_) continue;
+        p_seg = 0;
+        p_val = tmp_value;
+      } else {
+        all_flags_list[batch_size + origin_index] = 1;
+        if(partition_strategy_ == "mod"){
+          p_seg = tmp_value % num_partitions_;
+          p_val = tmp_value / num_partitions_;
+        } else if(partition_strategy_ == "div"){
+          p_seg = tmp_value < extras * (ids_per_partition + 1) ?
+                    tmp_value / (ids_per_partition + 1) :
+                    (tmp_value - extras) / ids_per_partition;
+          p_val = p_seg < extras ?
+                    tmp_value % (ids_per_partition + 1) :
+                    (tmp_value - extras) % ids_per_partition;
+        }
+      }
+
+      new_index_[p_seg].push_back({origin_index, p_val});
+      indices_set.insert(indices[origin_index].row);
+    }
+
+    // 2.3 fill_empty_row_index_
+    if (fill_empty_row_){
+      // get default id p_seg_ and p_val_
+      if(partition_strategy_ == "mod"){
+        fill_empty_row_p_seg_ = default_id % num_partitions_;
+        fill_empty_row_p_val_ = default_id / num_partitions_;
+      } else if(partition_strategy_ == "div"){
+        fill_empty_row_p_seg_ = default_id < extras * (ids_per_partition + 1) ?
+                  default_id / (ids_per_partition + 1) :
+                  (default_id - extras) / ids_per_partition;
+        fill_empty_row_p_val_ = fill_empty_row_p_seg_ < extras ?
+                  default_id % (ids_per_partition + 1) :
+                  (default_id - extras) % ids_per_partition;
+      }
+
+      for (int64_t origin_index = 0; origin_index < batch_size; ++origin_index){
+        if(indices_set.count(origin_index)){
+          all_flags_list[origin_index] = 0;
+          continue;
+        }
+        all_flags_list[origin_index] = 1;
+        fill_empty_row_index_.push_back({origin_index, 0});
+      }
+    }
+
+    // 3 packaging the output tensor
+    for (int i = 0; i < num_partitions_; ++i) {
+      int64_t size = new_index_[i].size();
+      if (fill_empty_row_ && i == fill_empty_row_p_seg_){
+        size += fill_empty_row_index_.size();
+      }
+
+      Tensor* sub_partitioned_values;
+      OP_REQUIRES_OK(ctx, partitioned_values.allocate(
+                              i, TensorShape({static_cast<int64_t>(size)}),
+                              &sub_partitioned_values));
+      int64_t* sub_partitioned_values_data = reinterpret_cast<int64_t*>(
+          sub_partitioned_values->flat<int64>().data());
+
+      Tensor* sub_partitioned_indices;
+      OP_REQUIRES_OK(ctx, partitioned_indices.allocate(
+                              i, TensorShape({static_cast<int64_t>(size), 2}),
+                              &sub_partitioned_indices));
+
+      IndicePair* sub_partitioned_indices_data = reinterpret_cast<IndicePair*>(
+                                  sub_partitioned_indices->flat<int64>().data());
+
+      if (!size) continue;
+
+      for (int j = 0; j < new_index_[i].size(); ++j){
+        sub_partitioned_values_data[j] = new_index_[i][j].column;
+        sub_partitioned_indices_data[j] = indices[new_index_[i][j].row];
+      }
+
+      if (fill_empty_row_ && i == fill_empty_row_p_seg_){
+        for (int j = 0, l = new_index_[i].size(); j < fill_empty_row_index_.size(); ++j, ++l){
+          sub_partitioned_values_data[l] = fill_empty_row_p_val_;
+          sub_partitioned_indices_data[l] = fill_empty_row_index_[j];
+        }
+      }
+    }
+  }
+
+ private:
+  int num_partitions_;
+  int partition_total_sizes_;
+  int partition_axis_;
+  bool fill_empty_row_;
+  bool prune_invalid_id_;
+  int64_t default_id_;
+  std::string partition_strategy_;
+};
+
+
+REGISTER_KERNEL_BUILDER(                                         \
+    Name("FusedEmbeddingSparsePreLookUp")                        \
+    .Device(DEVICE_CPU)                                          \
+    .HostMemory("partition_shapes")                              \
+    .HostMemory("sp_dense_shape"),                               \
+    FusedEmbeddingSparsePreLookUpCPU);
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_pre_op_test.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_pre_op_test.cc
@@ -1,0 +1,362 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <stdio.h>
+
+#include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/platform/test_benchmark.h"
+#include "tensorflow/core/public/session.h"
+
+namespace tensorflow {
+namespace {
+
+enum class Device { CPU, GPU };
+
+class FusedEmbeddingSparsePreLookUpOpTest : public OpsTestBase {
+ protected:
+  void MakeOpAndSetDevice(Device device, const int num_partitions,
+                          const bool fill_empty_row,
+                          const bool prune_invalid_id, const int default_id,
+                          const string partition_strategy = "div") {
+    if (device == Device::GPU) {
+      SetDevice(DEVICE_GPU,
+                std::unique_ptr<tensorflow::Device>(DeviceFactory::NewDevice(
+                    "GPU", {}, "/job:a/replica:0/task:0")));
+    }
+
+    TF_EXPECT_OK(NodeDefBuilder("FusedEmbeddingSparsePreLookUp",
+                                "FusedEmbeddingSparsePreLookUp")
+                     .Attr("num_partitions", num_partitions)
+                     .Attr("partition_strategy", partition_strategy)
+                     .Attr("partition_axis", 0)
+                     .Attr("fill_empty_row", fill_empty_row)
+                     .Attr("prune_invalid_id", prune_invalid_id)
+                     .Attr("default_id", default_id)
+                     .Input(FakeInput(num_partitions, DT_INT64))
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(DT_INT64))
+                     .Finalize(node_def()));
+    TF_EXPECT_OK(InitOp());
+  }
+};
+
+TEST_F(FusedEmbeddingSparsePreLookUpOpTest, Partition3_Int64) {
+  MakeOpAndSetDevice(Device::CPU, 3, false, false, -1);
+  // partition_shapes 0
+  AddInputFromArray<int64>(TensorShape({2}), {6, 16});
+  // partition_shapes 1
+  AddInputFromArray<int64>(TensorShape({2}), {3, 16});
+  // partition_shapes 2
+  AddInputFromArray<int64>(TensorShape({2}), {7, 16});
+  // sp_values
+  AddInputFromArray<int64>(TensorShape({12}),
+                           {1, 5, 3, 6, 12, 14,
+                           15, 0, 5, 5, 11, 7});
+  // sp_indices
+  AddInputFromArray<int64>(TensorShape({12, 2}),
+                           {2,  3, 4,  6, 1, 6, 12, 12, 12, 12, 11, 5,
+                            15, 0, 11, 6, 7, 9, 11, 8,  12, 13, 13, 0});
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {16, 16});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({6}));
+    test::FillValues<int64>(&expected_values, {1, 5, 3, 0, 5, 5});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(0));
+
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({6, 2}));
+    test::FillValues<int64>(&expected_indices,
+                            {2, 3, 4, 6, 1, 6, 11, 6, 7, 9, 11, 8});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(3));
+  }
+
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({2}));
+    test::FillValues<int64>(&expected_values, {0, 1});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(1));
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({2, 2}));
+    test::FillValues<int64>(&expected_indices, {12, 12, 13, 0});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(4));
+  }
+
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({4}));
+    test::FillValues<int64>(&expected_values, {1, 3, 4, 0});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(2));
+
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({4, 2}));
+    test::FillValues<int64>(&expected_indices, {12, 12, 11, 5, 15, 0, 12, 13});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(5));
+  }
+}
+
+TEST_F(FusedEmbeddingSparsePreLookUpOpTest, Partition2_Fill_Empty) {
+  MakeOpAndSetDevice(Device::CPU, 2, true, false, -1);
+  // partition_shapes 0
+  AddInputFromArray<int64>(TensorShape({2}), {5, 8});
+  // partition_shapes 1
+  AddInputFromArray<int64>(TensorShape({2}), {5, 8});
+
+  // sp_values
+  AddInputFromArray<int64>(TensorShape({10}),
+                           {0, 4, 3, -2, 5, 
+                           -3, -4, 9, -6, 2});
+
+  // sp_indices
+  AddInputFromArray<int64>(
+      TensorShape({10, 2}),
+      {0, 0, 0, 4, 1, 2, 3, 0, 3, 4, 
+       4, 0, 5, 2, 6, 0, 6, 1, 6, 7});
+
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {7, 8});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({9}));
+    test::FillValues<int64>(&expected_values, {0, 4, 3, -2, -3, -4, -6, 2, 0});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(0));
+
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({9, 2}));
+    test::FillValues<int64>(&expected_indices, {0, 0, 0, 4, 1, 2, 3, 0,
+                                                4, 0, 5, 2, 6, 1, 6, 7, 2, 0});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(2));
+  }
+
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({2}));
+    test::FillValues<int64>(&expected_values, {0, 4});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(1));
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({2, 2}));
+    test::FillValues<int64>(&expected_indices, {3, 4, 6, 0});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(3));
+  }
+}
+
+TEST_F(FusedEmbeddingSparsePreLookUpOpTest,
+       Partition2_Fill_Empty_Prune_Invalid) {
+  MakeOpAndSetDevice(Device::CPU, 2, true, true, -1);
+  // partition_shapes 0
+  AddInputFromArray<int64>(TensorShape({2}), {5, 8});
+  // partition_shapes 1
+  AddInputFromArray<int64>(TensorShape({2}), {5, 8});
+
+  // sp_values
+  AddInputFromArray<int64>(TensorShape({10}),
+                           {0, 4, 3, -2, 5,
+                           -3, -4, 9, -6, 2});
+
+  // sp_indices
+  AddInputFromArray<int64>(
+      TensorShape({10, 2}),
+      {0, 0, 0, 4, 1, 2, 3, 0, 3, 4, 
+       4, 0, 5, 2, 6, 0, 6, 1, 6, 7});
+
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {7, 8});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({7}));
+    test::FillValues<int64>(&expected_values, {0, 4, 3, 2, 0, 0, 0});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(0));
+
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({7, 2}));
+    test::FillValues<int64>(&expected_indices,
+                            {0, 0, 0, 4, 1, 2, 6, 7, 2, 0, 4, 0, 5, 0});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(2));
+  }
+
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({2}));
+    test::FillValues<int64>(&expected_values, {0, 4});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(1));
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({2, 2}));
+    test::FillValues<int64>(&expected_indices, {3, 4, 6, 0});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(3));
+  }
+}
+
+TEST_F(FusedEmbeddingSparsePreLookUpOpTest,
+       Partition2_Fill_Empty_Prune_Invalid_Default_7) {
+  MakeOpAndSetDevice(Device::CPU, 2, true, true, 7);
+  // partition_shapes 0
+  AddInputFromArray<int64>(TensorShape({2}), {5, 8});
+  // partition_shapes 1
+  AddInputFromArray<int64>(TensorShape({2}), {5, 8});
+
+  // sp_values
+  AddInputFromArray<int64>(TensorShape({10}),
+                           {0, 4, 3, -2, 5,
+                           -3, -4, 9, -6, 2});
+
+  // sp_indices
+  AddInputFromArray<int64>(
+      TensorShape({10, 2}),
+      {0, 0, 0, 4, 1, 2, 3, 0, 3, 4, 
+       4, 0, 5, 2, 6, 0, 6, 1, 6, 7});
+
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {7, 8});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({4}));
+    test::FillValues<int64>(&expected_values, {0, 4, 3, 2});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(0));
+
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({4, 2}));
+    test::FillValues<int64>(&expected_indices,
+                            {0, 0, 0, 4, 1, 2, 6, 7});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(2));
+  }
+
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({5}));
+    test::FillValues<int64>(&expected_values, {0, 4, 2, 2, 2});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(1));
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({5, 2}));
+    test::FillValues<int64>(&expected_indices, {3, 4, 6, 0, 2, 0, 4, 0, 5, 0});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(3));
+  }
+}
+
+TEST_F(FusedEmbeddingSparsePreLookUpOpTest,
+       Partition2_Prune_Invalid_Default_3) {
+  MakeOpAndSetDevice(Device::CPU, 2, false, true, 3);
+  // partition_shapes 0
+  AddInputFromArray<int64>(TensorShape({2}), {5, 8});
+  // partition_shapes 1
+  AddInputFromArray<int64>(TensorShape({2}), {5, 8});
+
+  // sp_values
+  AddInputFromArray<int64>(TensorShape({10}),
+                           {0, 4, 3, -2, 5,
+                           -3, -4, 9, -6, 2});
+
+  // sp_indices
+  AddInputFromArray<int64>(
+      TensorShape({10, 2}),
+      {0, 0, 0, 4, 1, 2, 3, 0, 3, 4, 
+       4, 0, 5, 2, 6, 0, 6, 1, 6, 7});
+
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {7, 8});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({4}));
+    test::FillValues<int64>(&expected_values, {0, 4, 3, 2});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(0));
+
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({4, 2}));
+    test::FillValues<int64>(&expected_indices,
+                            {0, 0, 0, 4, 1, 2, 6, 7});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(2));
+  }
+
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({2}));
+    test::FillValues<int64>(&expected_values, {0, 4});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(1));
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({2, 2}));
+    test::FillValues<int64>(&expected_indices, {3, 4, 6, 0});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(3));
+  }
+}
+
+TEST_F(FusedEmbeddingSparsePreLookUpOpTest, Partition1) {
+  MakeOpAndSetDevice(Device::CPU, 1, false, false, -1);
+  // partition_shapes 0
+  AddInputFromArray<int64>(TensorShape({2}), {10, 8});
+
+  // sp_values
+  AddInputFromArray<int64>(TensorShape({10}),
+                           {0, 4, 3, -2, 5, -3, -4, 9, -6, 2});
+
+  // sp_indices
+  AddInputFromArray<int64>(
+      TensorShape({10, 2}),
+      {0, 0, 0, 4, 1, 2, 3, 0, 3, 4, 4, 0, 5, 2, 6, 0, 6, 1, 6, 7});
+
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {7, 8});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({10}));
+    test::FillValues<int64>(&expected_values,
+                            {0, 4, 3, -2, 5, -3, -4, 9, -6, 2});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(0));
+
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({10, 2}));
+    test::FillValues<int64>(&expected_indices, {0, 0, 0, 4, 1, 2, 3, 0, 3, 4,
+                                                4, 0, 5, 2, 6, 0, 6, 1, 6, 7});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(1));
+  }
+}
+
+TEST_F(FusedEmbeddingSparsePreLookUpOpTest,
+       Partition1_Fill_Empty_Prune_Invalid_Default_3) {
+  MakeOpAndSetDevice(Device::CPU, 1, true, true, 3);
+  // partition_shapes 0
+  AddInputFromArray<int64>(TensorShape({2}), {10, 8});
+
+  // sp_values
+  AddInputFromArray<int64>(TensorShape({10}),
+                           {0, 4, 3, -2, 5, -3, -4, 9, -6, 2});
+
+  // sp_indices
+  AddInputFromArray<int64>(
+      TensorShape({10, 2}),
+      {0, 0, 0, 4, 1, 2, 3, 0, 3, 4, 4, 0, 5, 2, 6, 0, 6, 1, 6, 7});
+
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {7, 8});
+
+  TF_ASSERT_OK(RunOpKernel());
+  TF_EXPECT_OK(device_->Sync());
+
+  {
+    Tensor expected_values(allocator(), DT_INT64, TensorShape({9}));
+    test::FillValues<int64>(&expected_values, {0, 4, 3, 5, 9, 2, 3, 3, 3});
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(0));
+
+    Tensor expected_indices(allocator(), DT_INT64, TensorShape({9, 2}));
+    test::FillValues<int64>(&expected_indices, {0, 0, 0, 4, 1, 2, 3, 4, 6, 0, 6,
+                                                7, 2, 0, 4, 0, 5, 0});
+    test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(1));
+  }
+}
+
+}  // namespace
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_pre_op_test.cc
+++ b/tensorflow/core/kernels/fused_embedding/embedding_lookup_sparse_pre_op_test.cc
@@ -25,7 +25,7 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/platform/test_benchmark.h"
 #include "tensorflow/core/public/session.h"
-
+#include "tensorflow/cc/ops/standard_ops.h"
 namespace tensorflow {
 namespace {
 
@@ -117,7 +117,7 @@ TEST_F(FusedEmbeddingSparsePreLookUpOpTest, Partition2_Fill_Empty) {
   // partition_shapes 0
   AddInputFromArray<int64>(TensorShape({2}), {5, 8});
   // partition_shapes 1
-  AddInputFromArray<int64>(TensorShape({2}), {5, 8});
+  AddInputFromArray<int64>(TensorShape({2}), {5, 8}); 
 
   // sp_values
   AddInputFromArray<int64>(TensorShape({10}),
@@ -127,7 +127,7 @@ TEST_F(FusedEmbeddingSparsePreLookUpOpTest, Partition2_Fill_Empty) {
   // sp_indices
   AddInputFromArray<int64>(
       TensorShape({10, 2}),
-      {0, 0, 0, 4, 1, 2, 3, 0, 3, 4, 
+      {0, 0, 0, 4, 1, 2, 3, 0, 3, 4,
        4, 0, 5, 2, 6, 0, 6, 1, 6, 7});
 
   // sp_dense_shape
@@ -349,7 +349,7 @@ TEST_F(FusedEmbeddingSparsePreLookUpOpTest,
   {
     Tensor expected_values(allocator(), DT_INT64, TensorShape({9}));
     test::FillValues<int64>(&expected_values, {0, 4, 3, 5, 9, 2, 3, 3, 3});
-    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(0));
+    test::ExpectTensorEqual<int64>(expected_values, *GetOutput(0));;
 
     Tensor expected_indices(allocator(), DT_INT64, TensorShape({9, 2}));
     test::FillValues<int64>(&expected_indices, {0, 0, 0, 4, 1, 2, 3, 4, 6, 0, 6,
@@ -357,6 +357,183 @@ TEST_F(FusedEmbeddingSparsePreLookUpOpTest,
     test::ExpectTensorEqual<int64>(expected_indices, *GetOutput(1));
   }
 }
+
+TEST_F(FusedEmbeddingSparsePreLookUpOpTest, Partition3_Int64_Perfs) {
+
+  int num_partitions = 4;
+  int batch_size = 100000;
+  int num_per_part = batch_size / num_partitions;
+  int embed_dim = 32;
+  int default_id = -1;
+
+  std::vector<int64> sp_values;
+  std::vector<int64> sp_indices;
+
+  MakeOpAndSetDevice(Device::CPU, num_partitions, false, false, default_id);
+
+  for(int i = 0; i < num_partitions; ++i){
+    AddInputFromArray<int64>(TensorShape({2}), {num_per_part * embed_dim, embed_dim});
+  }
+
+  for(int i = 0; i < batch_size * embed_dim; ++i){
+    sp_values.push_back(i);
+  }
+
+  for(int i = 0; i < batch_size; ++i){
+    for(int j = 0; j < embed_dim; ++j){
+      sp_indices.push_back(i);
+      sp_indices.push_back(j);
+    }
+  }
+  // sp_values
+  AddInputFromArray<int64>(TensorShape({sp_values.size()}), sp_values);
+  // sp_indices
+  AddInputFromArray<int64>(TensorShape({sp_values.size(), 2}), sp_indices);
+  // sp_dense_shape
+  AddInputFromArray<int64>(TensorShape({2}), {batch_size, embed_dim});
+  TF_ASSERT_OK(RunOpKernel());
+}
+
+
+
+//----------------------------------------------------------------------------//
+// Performance benchmarks                                                     //
+//----------------------------------------------------------------------------//
+
+template <typename T>
+void FillValues(Tensor* tensor, gtl::ArraySlice<T> vals) {
+  auto flat = tensor->flat<T>();
+  CHECK_EQ(flat.size(), vals.size());
+  if (flat.size() > 0) {
+    std::copy_n(vals.data(), vals.size(), flat.data());
+  }
+}
+
+template <typename T>
+void FillZerosValues(Tensor* tensor) {
+  auto flat = tensor->flat<T>();
+  for (int i = 0; i < flat.size(); ++i) {
+    flat.data()[i] = 0.0;
+  }
+}
+
+template <typename T>
+void FillOnesValues(Tensor* tensor) {
+  auto flat = tensor->flat<T>();
+  float scale = std::rand()/((RAND_MAX + 1u)/6);
+  for (int i = 0; i < flat.size(); ++i) {
+    flat.data()[i] = 1.1 * scale;
+  }
+}
+
+template <typename T>
+void FillIndiceValues(Tensor* tensor, const int partitions, const int batch_size, const int entries) {
+  auto flat = tensor->flat<T>();
+  int k = 0;
+  for (int i = 0; i < batch_size; ++i) {
+    for (int j = 0; j < entries; ++j) {
+      flat.data()[k] = i + partitions;
+      flat.data()[k+1] = j;
+      k += 2;
+    }
+  }
+}
+
+template <typename T>
+void PrintValues(Tensor* tensor) {
+  auto flat = tensor->flat<T>();
+  for (int i = 0; i < flat.size(); ++i) {
+    std::cout << flat.data()[i] << ", ";
+  }
+  std::cout << std::endl;
+}
+
+template <typename T>
+static Graph* EmbPreOp(const string& kind, int num_partitions, const std::string& combiner,
+                      const float max_norm, const int default_id) {
+  
+  int batch_size = 100000;
+  int num_per_part = batch_size / num_partitions;
+  int embed_dim = 32;
+  const string partition_strategy = "div";
+  const bool fill_empty_row = false;
+  const bool prune_invalid_id = false;
+
+  Graph* g = new Graph(OpRegistry::Global());
+  DataType type = DataTypeToEnum<T>::v();
+
+  const bool isDefault = (kind == "Default");
+  string op_name = isDefault ? "FusedEmbeddingSparsePreLookUp" : "FusedEmbeddingSparsePreLookUp";
+
+  std::vector<int64> sp_values;
+  std::vector<int64> sp_indices;
+
+  // partitioned_indices
+  std::vector<NodeBuilder::NodeOut> partitioned_indices;
+  partitioned_indices.reserve(num_partitions);
+  for (int i = 0; i < num_partitions; ++i) {
+    Tensor sub_partitioned_indice(DT_INT64, TensorShape({2}));
+    FillValues<int64>(&sub_partitioned_indice, {num_per_part * embed_dim, embed_dim});
+    partitioned_indices.push_back(test::graph::Constant(g, sub_partitioned_indice));
+  }
+
+  for(int i = 0; i < batch_size * embed_dim; ++i){
+    sp_values.push_back(i);
+  }
+
+  for(int i = 0; i < batch_size; ++i){
+    for(int j = 0; j < embed_dim; ++j){
+      sp_indices.push_back(i);
+      sp_indices.push_back(j);
+    }
+  }
+
+  // sp_values
+  Tensor sp_values_t(DT_INT64, TensorShape({sp_values.size()}));
+  FillValues<int64>(&sp_values_t, sp_values);
+
+  // sp_indices
+  Tensor sp_indices_t(DT_INT64, TensorShape({sp_values.size(), 2}));
+  FillValues<int64>(&sp_indices_t, sp_indices);
+
+  // sp_dense_shape
+  Tensor sp_dense_shape_t(DT_INT64, TensorShape({2}));
+  FillValues<int64>(&sp_dense_shape_t, {batch_size, embed_dim});
+
+  auto nodeBuilder = NodeBuilder(g->NewName("n"), op_name)
+                    .Attr("num_partitions", num_partitions)
+                    .Attr("partition_strategy", partition_strategy)
+                    .Attr("partition_axis", 0)
+                    .Attr("fill_empty_row", fill_empty_row)
+                    .Attr("prune_invalid_id", prune_invalid_id)
+                    .Attr("default_id", default_id)
+                    .Input(partitioned_indices)
+                    .Input(test::graph::Constant(g, sp_values_t))
+                    .Input(test::graph::Constant(g, sp_indices_t))
+                    .Input(test::graph::Constant(g, sp_dense_shape_t));
+  TF_CHECK_OK(nodeBuilder.Finalize(g, nullptr));
+  return g;
+}
+
+#define BM_EMB_PRE_OP(kind, NP, C, T, DEVICE, NTH)                                \
+  static void BM_EMB_PRE_OP##_##kind##_##NP##_##C##_##T##_##DEVICE##_##NTH(       \
+      int iters) {                                                                \
+    testing::UseRealTime();                                                       \
+    SessionOptions opts;                                                          \
+    opts.config.set_intra_op_parallelism_threads(NTH);                            \
+    test::Benchmark(#DEVICE, EmbPreOp<T>(#kind, NP, #C, -1.0, -1), &opts).Run(iters); \
+  }                                                                               \
+  BENCHMARK(BM_EMB_PRE_OP##_##kind##_##NP##_##C##_##T##_##DEVICE##_##NTH);        \
+
+#define BM_EMB_PRE_OP_kind(NP, C, NTH)            \
+  BM_EMB_PRE_OP(OPT, NP, C, float, CPU, NTH);     \
+
+#define BM_EMB_PRE_OP_NTH(NP, C) \
+  BM_EMB_PRE_OP_kind(NP, C, 1);  \
+  // BM_EMB_PRE_OP_kind(NP, C, 4);  \
+  // BM_EMB_PRE_OP_kind(NP, C, 8);  \
+
+BM_EMB_PRE_OP_NTH(4, sum);
 
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/python/ops/fused_embedding_ops.py
+++ b/tensorflow/python/ops/fused_embedding_ops.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import tensorflow
 from tensorflow.python.framework.constant_op import constant
+from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import variables
 from tensorflow.python.ops import array_ops
@@ -47,7 +48,7 @@ def fused_embedding_lookup_sparse(params,
     if partition_nums != 1:
       raise ValueError("For EmbeddingVariable, do not support partition now")
     # fake shape for now. TBD change in the future
-    partition_shapes = [constant([1, 1], dtype=tensorflow.int64)]
+    partition_shapes = [constant([1, 1], dtype=dtypes.int64)]
   else:
     partition_shapes = [w.shape for w in params]
 
@@ -63,6 +64,10 @@ def fused_embedding_lookup_sparse(params,
           default_id=default_id,
           prune_invalid_id=bool(prune_invalid_ids)
       )
+    
+    # fixme(marvin): pls combine the logic of default_id
+    default_id = default_id is not None if default_id else 0
+
     emb_shards = []
     for i in range(partition_nums):
       param = params[i]

--- a/tensorflow/python/ops/fused_embedding_ops.py
+++ b/tensorflow/python/ops/fused_embedding_ops.py
@@ -64,9 +64,9 @@ def fused_embedding_lookup_sparse(params,
           default_id=default_id,
           prune_invalid_id=bool(prune_invalid_ids)
       )
-    
-    # fixme(marvin): pls combine the logic of default_id
-    default_id = default_id is not None if default_id else 0
+
+    # fixme(marvin): ple align the meaning between pre & post op.
+    default_id = 0 if default_id is None else default_id
 
     emb_shards = []
     for i in range(partition_nums):


### PR DESCRIPTION
Verificate CPU embedding ops:
```bash
$ bazel test --flaky_test_attempts 1 --test_output=all --nocache_test_results --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow/core/kernels:embedding_lookup_sparse_pre_op_test
$ bazel test --flaky_test_attempts 1 --test_output=all --nocache_test_results --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow/core/kernels:embedding_lookup_sparse_post_op_test
$ bazel test --flaky_test_attempts 1 --test_output=all --nocache_test_results --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow/core/kernels:embedding_lookup_sparse_post_grad_op_test
```

Currently, only integrated functionality code and accuracy is right, will increase its perf.



## Result

| ACC | WDL | WDL | DLRM | DLRM | Deep FM | Deep FM | DSSM  | DSSM |
| -- | -- | -- | -- | -- | -- | -- | -- | -- |
|  | value | percent | value | percent | value | percent | value | percent |
| DeepRec FP32 | 0.745967 | baseline | 0.745967 | baseline | 0.745968 | baseline | 0.946699 | baseline |
| DeepRec BF16 | 0.745967 | baseline | 0.745996 | baseline | 0.745967 | baseline | 0.946699 | baseline |
| DeepRec FP32 fusion | 0.745967 | 100.00% | 0.745968 | 100.00% | 0.745968 | 100.00% | 0.946699 | 100.00% |
| DeepRec BF16 fusion | 0.745967 | 100.00% | 0.745995 | 100.00% | 0.745967 | 100.00% | 0.946699 | 100.00% |

| AUC | WDL | WDL | DLRM | DLRM | Deep FM | Deep FM | DSSM | DSSM |
| -- | -- | -- | -- | -- | -- | -- | -- | -- |
|  | value | percent | value | percent | value | percent | value | percent |
| DeepRec FP32 | 0.765685 | baseline | 0.768976 | baseline | 0.784281 | baseline | 0.499681 | baseline |
| DeepRec BF16 | 0.765803 | baseline | 0.761704 | baseline | 0.781633 | baseline | 0.505126 | baseline |
| DeepRec FP32 fusion | 0.765685 | 100.00% | 0.764456 | 99.41% | 0.784281 | 100.00% | 0.505358 | 101.14% |
| DeepRec BF16 fusion | 0.765803 | 100.00% | 0.762161 | 100.06% | 0.781633 | 100.00% | 0.503907 | 99.76% |

| Gsteps/s |  | WDL | WDL | DLRM | DLRM | Deep FM | Deep FM | DSSM | DSSM |
| -- | -- | -- | -- |  -- | -- | -- | -- | -- | -- |
|  |  | value | percent | value | percent | value | percent | value | percent |
| Other optimization On | DeepRec FP32 | 33.50265 | baseline | 99.95526 | baseline | 66.04759 | baseline | 28.36769 | baseline |
|  | DeepRec BF16 | 48.41496 | baseline | 109.12015 | baseline | 74.05916 | baseline | 31.50646 | baseline |
|  | DeepRec FP32 fusion | 34.78501 | 103.83% | 104.0153 | 104.06% | 67.84789 | 102.73% | 29.55832 | 104.20% |
|  | DeepRec BF16 fusion | 49.8682 | 103.00% | 114.04472 | 104.51% | 77.80101 | 105.05% | 32.90028 | 104.42% |
| Other optimization Off | DeepRec FP32 | 32.72904 | baseline | 91.23718 | baseline | 59.58345 | baseline | 25.72757 | baseline |
|  | DeepRec BF16 | 46.05335 | baseline | 99.55281 | baseline | 67.69607 | baseline | 27.78738 | baseline |
|  | DeepRec FP32 fusion | 33.20884 | 101.47% | 94.874 | 103.99% | 63.1486 | 105.98% | 26.69409 | 103.76% |
|  | DeepRec BF16 fusion | 47.46906 | 103.07% | 103.96462 | 104.43% | 73.87731 | 109.13% | 29.3384 | 105.58% |
