### PR TITLE
[CIBUILD] Disable ev_allocator_tests in cpu/gpu core ut.

### DIFF
--- a/cibuild/cpu-ut/cpu-core-ut.sh
+++ b/cibuild/cpu-ut/cpu-core-ut.sh
@@ -39,6 +39,7 @@ export TF_BUILD_BAZEL_TARGET="$TF_ALL_TARGETS "\
 "-//tensorflow/core/distributed_runtime/eager:remote_mgr_test "\
 "-//tensorflow/core/distributed_runtime:session_mgr_test "\
 "-//tensorflow/core/debug:grpc_session_debug_test "\
+"-//tensorflow/core:ev_allocator_tests "\
 
 for i in $(seq 1 3); do
     [ $i -gt 1 ] && echo "WARNING: cmd execution failed, will retry in $((i-1)) times later" && sleep 2

--- a/cibuild/gpu-ut/gpu-core-ut.sh
+++ b/cibuild/gpu-ut/gpu-core-ut.sh
@@ -71,6 +71,7 @@ export TF_BUILD_BAZEL_TARGET="$TF_ALL_TARGETS "\
 "-//tensorflow/core:common_runtime_hierarchical_tree_broadcaster_test "\
 "-//tensorflow/core:gpu_debug_allocator_test "\
 "-//tensorflow/core:common_runtime_gpu_pool_allocator_test "\
+"-//tensorflow/core:ev_allocator_tests "\
 
 for i in $(seq 1 3); do
     [ $i -gt 1 ] && echo "WARNING: cmd execution failed, will retry in $((i-1)) times later" && sleep 2


### PR DESCRIPTION
Disable ev_allocator_tests by default. Once ev_allocate bug is fixed, enable the test again.