### PR TITLE
Add clang-format rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+# Run manually to reformat a file:
+# clang-format -i --style=file <file>
+# find . -iname '*.cc' -o -iname '*.h' -o -iname '*.h.in' | xargs clang-format -i --style=file
+BasedOnStyle: Google
+DerivePointerAlignment: false


### PR DESCRIPTION
According to the [Contribution guidelines and standards](https://github.com/alibaba/DeepRec/blob/b8afd495b3985e442dccc107ae453edc0de4a07c/CONTRIBUTING.md#contribution-guidelines-and-standards), I add these rules hope to help DeepRec to maintain a consistent with existing coding style.

The rule file is forked from that in Google's repo like TensorFlow and leveldb.
