### PR TITLE
[Op] Parallelize UnsortedSegment op.

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops.cc
@@ -22,10 +22,9 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/segment_reduction_ops.h"
 
-#include <vector>
-
 #include "third_party/eigen3/Eigen/Core"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -383,24 +382,76 @@ struct UnsortedSegmentFunctor<CPUDevice, T, Index, InitialValueF, ReductionF> {
                   typename TTypes<Index>::ConstFlat segment_ids,
                   typename TTypes<T, 2>::ConstTensor data,
                   typename TTypes<T, 2>::Tensor output) {
-    output.setConstant(InitialValueF()());
+    auto cpu_device = ctx->eigen_cpu_device();
+    output.device(cpu_device) = output.constant(InitialValueF()());
     if (data.size() == 0) {
       return;
     }
+
+    // This functor will reduce `N` rows input to `num_segments` rows output.
     const int64 N = segment_ids.dimension(0);
     const int64 num_segments = output.dimension(0);
+    const int64_t inner_dim = data.dimension(1);
     ReductionF reduction;
+
+    // `num_real_segment` counts the rows actually reduced from input,
+    // the rows with negative segment index will be excluded.
+    // It will be used for cost model.
+    int64_t num_real_segment = N;
+    // `num_reductions` counts the rows actually reduced in output,
+    // the rows only filled with InitialValueF() will be excluded.
+    int64_t num_reductions = 0;
+    // `row_counter` records how many input rows will be reduced in each
+    // output row, the row only fills with InitialValueF() will keep 0.
+    // Length of non-zero elements is `num_reductions`.
+    std::vector<Index> row_counter(num_segments, 0);
     for (int64 i = 0; i < N; ++i) {
       Index j = internal::SubtleMustCopy(segment_ids(i));
       if (j < 0) {
+        --num_real_segment;
         continue;
       }
       OP_REQUIRES(ctx, FastBoundsCheck(j, num_segments),
                   errors::InvalidArgument(
                       "segment_ids", SliceDebugString(segment_ids_shape, i),
                       " = ", j, " is out of range [0, ", num_segments, ")"));
-      reduction(data.template chip<0>(i), output.template chip<0>(j));
+      if (row_counter[j] == 0) num_reductions++;
+      row_counter[j]++;
     }
+
+    // Nothing to reduce. All output values equal to `InitialValueF()`.
+    if (num_reductions == 0) return;
+
+    // Parallelize by `num_segments`. It's simple, efficient and safe
+    // (no data dependency):
+    //
+    //   input   segment_ids                 num_segments  operation
+    //   | a0 |  | 0 |            worker 1:  |0|           f(a0, a1)
+    //   | b0 |  | 1 |            worker 2:  |1|           f(b0, b1)
+    // N | c0 |  | 2 |       -->  worker 3:  |2|           f(c0)
+    //   | b1 |  | 1 |
+    //   | a1 |  | 0 |
+    //
+    // TODO(intel-tf): Balance workload in `row_counter` to make parallelism
+    //                 more efficient.
+    auto reductionWorker = [&](int64_t begin, int64_t end) -> void {
+      for (int64_t i = 0; i < N; i++) {
+        Index j = internal::SubtleMustCopy(segment_ids(i));
+        // If `j` is in work scope of this worker, do the reduction.
+        if (j >= begin && j < end) {
+          reduction(data.template chip<0>(i), output.template chip<0>(j));
+        }
+      }
+    };
+
+    // Reduction functors includes Sum, Max, Min, etc. Simply consider it
+    // will cost 5 cycles per operation.
+    const int64_t kAverTaskSize = num_real_segment / num_segments;
+    const int64_t compute_cycles = 5 * inner_dim * kAverTaskSize;
+    const int64_t input_bytes = sizeof(T) * inner_dim * kAverTaskSize;
+    const int64_t output_bytes = sizeof(T) * inner_dim * kAverTaskSize;
+    const Eigen::TensorOpCost cost(input_bytes, output_bytes, compute_cycles);
+    cpu_device.parallelFor(num_segments, cost, reductionWorker);
   }
 };
 
@@ -602,7 +653,6 @@ REGISTER_COMPLEX_CPU_UNSORTED_KERNELS_ALL(complex128);
 #define REGISTER_SUM_GPU_UNSORTED_KERNELS_ALL(type) \
   REGISTER_SUM_GPU_UNSORTED_KERNELS(type, int32);   \
   REGISTER_SUM_GPU_UNSORTED_KERNELS(type, int64);
-
 
 TF_CALL_GPU_NUMBER_TYPES(REGISTER_REAL_GPU_UNSORTED_KERNELS_ALL);
 TF_CALL_int32(REGISTER_REAL_GPU_UNSORTED_KERNELS_ALL);

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
@@ -480,6 +480,14 @@ class UnsortedSegmentTest(SegmentReductionHelper):
         self.assertAllClose(np_ans, tf_ans)
         self.assertShapeEqual(np_ans, s)
 
+  @test_util.run_deprecated_v1
+  def testAllNegatives(self):
+    with self.session(use_gpu=False):
+      data = np.ones((2, 1), dtype=np.float32)
+      segment_ids = np.array([-1, -1], dtype=np.int32)
+      unsorted = math_ops.unsorted_segment_sum(data, segment_ids, 2)
+      self.assertAllClose(unsorted.eval(), np.zeros((2, 1), dtype=np.float32))
+
 
 class SparseSegmentReductionHelper(SegmentReductionHelper):
 


### PR DESCRIPTION
Parallelize UnsortedSegmentSum on CPU deivce.

Under the same condition,  we can see the “parallel” way is more effective.
Op | Row | Col | S_id | T_nums
-- | -- | -- | -- | --
UnsortedSegmentSum | 4096 | 1024 | 128 | 1
UnsortedSegmentSum | 4096 | 1024 | 128 | 2
UnsortedSegmentSum | 4096 | 1024 | 128 | 4
UnsortedSegmentSum | 4096 | 1024 | 128 | 8
UnsortedSegmentSum | 4096 | 1024 | 128 | 16

![image](https://user-images.githubusercontent.com/19548774/168729992-efa6564a-3c59-4397-9a48-e3bf60afc4b1.png)
