### PR TITLE
[Profiler] Support more information attributes for the built-in profiler traces

### DIFF
--- a/serving/tools/timeline/timeline.py
+++ b/serving/tools/timeline/timeline.py
@@ -595,7 +595,6 @@ class Timeline(object):
                 self._chrome_trace.emit_flow_end(input_name, start_time,
                                                  device_pid, tid, flow_id)
               else:
-                print("######## Generate Horizontal Dataflow")
                 flow_id = self._alloc_flow_id()
                 self._chrome_trace.emit_flow_type_start("Horizontal Dataflow",
                                                    input_name, create_time,

--- a/serving/tools/timeline/timeline.py
+++ b/serving/tools/timeline/timeline.py
@@ -197,7 +197,7 @@ class _ChromeTraceFormatter(object):
     """
     event = self._create_event('s', 'DataFlow', name, pid, tid, timestamp)
     event['id'] = flow_id
-    self._events.append(event)
+    self._events.append(event)  
 
   def emit_flow_end(self, name, timestamp, pid, tid, flow_id):
     """Adds a flow end event to the trace.
@@ -215,6 +215,43 @@ class _ChromeTraceFormatter(object):
     event = self._create_event('t', 'DataFlow', name, pid, tid, timestamp)
     event['id'] = flow_id
     self._events.append(event)
+
+  def emit_flow_type_start(self, flow_type, name, timestamp, pid, tid, flow_id):
+    """Adds a flow start event to the trace.
+
+    When matched with a flow end event (with the same 'flow_id') this will
+    cause the trace viewer to draw an arrow between the start and end events.
+
+    Args:
+      flow_type: The flow event type name as a string
+      name:  The event name as a string.
+      timestamp:  The timestamp of this event as a long integer.
+      pid:  Identifier of the process generating this event as an integer.
+      tid:  Identifier of the thread generating this event as an integer.
+      flow_id: Identifier of the flow as an integer.
+    """
+    event = self._create_event('s', flow_type, name, pid, tid, timestamp)
+    event['id'] = flow_id
+    self._events.append(event)  
+
+  def emit_flow_type_end(self, flow_type, name, timestamp, pid, tid, flow_id):
+    """Adds a flow end event to the trace.
+
+    When matched with a flow start event (with the same 'flow_id') this will
+    cause the trace viewer to draw an arrow between the start and end events.
+
+    Args:
+      flow_type: The flow event type name as a string
+      name:  The event name as a string.
+      timestamp:  The timestamp of this event as a long integer.
+      pid:  Identifier of the process generating this event as an integer.
+      tid:  Identifier of the thread generating this event as an integer.
+      flow_id: Identifier of the flow as an integer.
+    """
+    event = self._create_event('t', flow_type, name, pid, tid, timestamp)
+    event['id'] = flow_id
+    self._events.append(event)
+
 
   def emit_counter(self, category, name, pid, timestamp, counter, value):
     """Emits a record for a single counter.
@@ -556,6 +593,16 @@ class Timeline(object):
                                                    create_pid, create_tid,
                                                    flow_id)
                 self._chrome_trace.emit_flow_end(input_name, start_time,
+                                                 device_pid, tid, flow_id)
+              else:
+                print("######## Generate Horizontal Dataflow")
+                flow_id = self._alloc_flow_id()
+                self._chrome_trace.emit_flow_type_start("Horizontal Dataflow",
+                                                   input_name, create_time,
+                                                   create_pid, create_tid,
+                                                   flow_id)
+                self._chrome_trace.emit_flow_type_end("Horizontal Dataflow",
+                                                 input_name, start_time,
                                                  device_pid, tid, flow_id)
           else:
             print ("Can not find tensor ", input_name, " - removed by CSE?")

--- a/tensorflow/core/common_runtime/step_stats_collector.cc
+++ b/tensorflow/core/common_runtime/step_stats_collector.cc
@@ -193,6 +193,14 @@ void NodeExecStatsWrapper::AddAllocation(
   allocations_.push_back(std::make_pair(memory, tracking_allocator));
 }
 
+void NodeExecStatsWrapper::SetActivityID(int64 id) {
+  stats_->set_correlation_id(id);
+}
+
+void NodeExecStatsWrapper::SetParentID(int64 id) {
+  stats_->set_parent_id(id);
+}
+
 void NodeExecStatsWrapper::Finalize() {
   for (auto& alloc : allocations_) {
     AllocatorMemoryUsed* memory = alloc.first;

--- a/tensorflow/core/common_runtime/step_stats_collector.h
+++ b/tensorflow/core/common_runtime/step_stats_collector.h
@@ -88,6 +88,9 @@ class NodeExecStatsInterface {
   // Records the absolute time in nanoseconds at which this node became
   // runnable (i.e. was scheduled for execution).
   virtual void SetScheduled(int64 nanos) = 0;
+
+  virtual void SetActivityID(int64 id) = 0;
+  virtual void SetParentID(int64 id) = 0;
 };
 
 // Wraps NodeExecStats and adds allocation to it.
@@ -115,6 +118,8 @@ class NodeExecStatsWrapper : public NodeExecStatsInterface {
   void SetOutput(int slot, const Tensor* tensor) override;
   void SetReferencedTensors(const TensorReferenceVector& tensors) override;
   void SetScheduled(int64 nanos) override;
+  void SetActivityID(int64 id) override;
+  void SetParentID(int64 id) override;
 
  private:
   friend class StepStatsCollector;

--- a/tensorflow/core/framework/step_stats.proto
+++ b/tensorflow/core/framework/step_stats.proto
@@ -72,6 +72,7 @@ message NodeExecStats {
   int64 op_end_rel_nanos = 15;
   int64 all_end_rel_nanos = 16;
   int64 scheduled_nanos = 17;
+  int64 correlation_id = 18;
 };
 
 message DeviceStepStats {

--- a/tensorflow/core/framework/step_stats.proto
+++ b/tensorflow/core/framework/step_stats.proto
@@ -73,6 +73,7 @@ message NodeExecStats {
   int64 all_end_rel_nanos = 16;
   int64 scheduled_nanos = 17;
   int64 correlation_id = 18;
+  int64 parent_id = 20;
 };
 
 message DeviceStepStats {

--- a/tensorflow/core/kernels/data/captured_function.cc
+++ b/tensorflow/core/kernels/data/captured_function.cc
@@ -92,6 +92,11 @@ class SimpleStepStatsCollector : public StepStatsCollectorInterface {
 
     void SetScheduled(int64 nanos) override {}
 
+
+    void SetActivityID(int64 id) override {}
+    
+    void SetParentID(int64 id) override {}
+
    private:
     int64 start_time_ns_ = 0;
     int64 end_time_ns_ = 0;

--- a/tensorflow/core/platform/annotation.cc
+++ b/tensorflow/core/platform/annotation.cc
@@ -20,4 +20,27 @@ namespace tensorflow {
   static thread_local std::string annotation;
   return &annotation;
 }
+
+namespace tracing {
+
+thread_local std::vector<uint64_t> CallingContext::Context_;
+
+// Moved from TraceMe
+// Activity IDs: To avoid contention over a counter, the top 32 bits identify
+// the originating thread, the bottom 32 bits name the event within a thread.
+// IDs may be reused after 4 billion events on one thread, or 4 billion threads.
+static std::atomic<uint32_t> thread_counter(1);  // avoid kUntracedActivity
+uint64_t NewActivityId() {
+  const thread_local static uint32_t thread_id = thread_counter.fetch_add(1);
+  thread_local static uint32_t per_thread_activity_id = 0;
+  return static_cast<uint64_t>(thread_id) << 32 | per_thread_activity_id++;
+}
+
+uint64_t CallingContext::GetAndPush() {
+  uint64_t id = NewActivityId();
+  Context_.push_back(id);
+  return id;
+}
+
+}  // namespace tracing
 }  // namespace tensorflow

--- a/tensorflow/core/platform/annotation.h
+++ b/tensorflow/core/platform/annotation.h
@@ -134,7 +134,12 @@ class CallingContext {
   public:
     static uint64_t GetCurrentContext() { return Context_.empty() ? 0 : Context_.back(); }
     static uint64_t GetAndPush();
-    static void Pop() { Context_.pop_back(); }
+    static void Pop() {
+      if (Context_.empty()) {
+        return;
+      }
+      Context_.pop_back();
+    }
   private:
     thread_local static std::vector<uint64_t> Context_;
 };

--- a/tensorflow/core/platform/annotation.h
+++ b/tensorflow/core/platform/annotation.h
@@ -130,6 +130,15 @@ class ScopedAnnotation {
   size_t old_length_ = kInvalidLength;
 };
 
+class CallingContext {
+  public:
+    static uint64_t GetCurrentContext() { return Context_.empty() ? 0 : Context_.back(); }
+    static uint64_t GetAndPush();
+    static void Pop() { Context_.pop_back(); }
+  private:
+    thread_local static std::vector<uint64_t> Context_;
+};
+
 }  // namespace tracing
 }  // namespace tensorflow
 

--- a/tensorflow/core/platform/default/device_tracer.cc
+++ b/tensorflow/core/platform/default/device_tracer.cc
@@ -134,11 +134,9 @@ class CudaEventRecorder {
     record.thread_id = Env::Default()->GetCurrentThreadId();
     // TODO: Make it lock-free for lower profiling overhead
     mutex_lock lock(mutex_);
-    //LOG(INFO) << "######### CudaEventRecorder StartKernel locked\n";
     if (tracing::ScopedAnnotation::IsEnabled()) {
       record.annotation =
           &*annotations_.emplace(Annotation::CurrentAnnotation()).first;
-      LOG(INFO) << "######### CudaEventRecorder StartKernel " << kernel_name << " " << *record.annotation << "\n";
     }
     record.op_context = tracing::CallingContext::GetCurrentContext();
     kernel_records_.push_back(record);
@@ -576,7 +574,6 @@ class CudaEventCollector {
 
     auto stats = absl::make_unique<NodeExecStats>();
     std::string node_name = port::MaybeAbiDemangle(record.kernel_name);
-    LOG(INFO) << "### SaveRecord " << record.kernel_name << " ## Demangled ## " << node_name << " ## " << start_us << ", " << elapsed_us << ", " << record.launch_start_us << ", " << record.launch_end_us << ", " << start_us-record.launch_start_us << "\n";
     // Sometimes CUPTI returns invalid characters. See b/129892466.
     if (!IsAscii(node_name)) {
       node_name = "<invalid_name>";

--- a/tensorflow/core/platform/default/device_tracer.cc
+++ b/tensorflow/core/platform/default/device_tracer.cc
@@ -585,6 +585,8 @@ class CudaEventCollector {
       node_name = absl::StrCat(*record.annotation, "@@", node_name);
     }
     stats->set_node_name(node_name);
+    // thread id is meaningless for kernel events, but useful for kernel launch events
+    stats->set_thread_id(record.thread_id);
     // TODO(csigg): Report grid size?
     std::string node_label;
     stats->set_timeline_label(node_label);
@@ -618,6 +620,8 @@ class CudaEventCollector {
       node_name = absl::StrCat(*record.annotation, "@@", node_name);
     }
     stats->set_node_name(node_name);
+    // thread id is meaningless for kernel events, but useful for kernel launch events
+    stats->set_thread_id(record.thread_id);
     // TODO(csigg): Show label in Chrome trace viewer.
     std::string node_label = absl::StrFormat("%d bytes", record.size_bytes);
     stats->set_timeline_label(node_label);

--- a/tensorflow/core/platform/posix/env.cc
+++ b/tensorflow/core/platform/posix/env.cc
@@ -43,7 +43,6 @@ namespace tensorflow {
 
 namespace {
 
-static std::atomic<uint32_t> thread_counter(0);
 mutex name_mutex(tensorflow::LINKER_INITIALIZED);
 
 std::map<std::thread::id, string>& GetThreadNameRegistry()

--- a/tensorflow/core/platform/posix/env.cc
+++ b/tensorflow/core/platform/posix/env.cc
@@ -118,19 +118,14 @@ class PosixEnv : public Env {
   }
 
   int32 GetCurrentThreadId() override {
-#ifdef USE_OS_ID
-#  ifdef __APPLE__
+#ifdef __APPLE__
     uint64_t tid64;
     pthread_threadid_np(nullptr, &tid64);
     return static_cast<int32>(tid64);
-#  elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__)
     return pthread_getthreadid_np();
-#  else
-    return static_cast<int32>(pthread_self());
-#  endif
 #else
-    const thread_local static uint32_t thread_id = thread_counter.fetch_add(1);
-    return thread_id;
+    return static_cast<int32>(pthread_self());
 #endif
   }
 

--- a/tensorflow/core/profiler/internal/cpu/host_tracer.cc
+++ b/tensorflow/core/profiler/internal/cpu/host_tracer.cc
@@ -129,6 +129,8 @@ Status HostTracer::CollectData(RunMetadata* run_metadata) {
         ns->set_all_end_rel_micros((event.end_time - event.start_time) /
                                    EnvTime::kMicrosToNanos);
         ns->set_thread_id(thread.thread.tid);
+        ns->set_correlation_id(event.activity_id);
+        ns->set_parent_id(event.parent_id);
         // TODO(fishx): Add thread name to RunMetadata
         step_stats_collector.Save(cpu_name, ns);
       }

--- a/tensorflow/core/profiler/internal/traceme_recorder.h
+++ b/tensorflow/core/profiler/internal/traceme_recorder.h
@@ -48,6 +48,7 @@ class TraceMeRecorder {
     string name;
     uint64 start_time;  // 0 = missing
     uint64 end_time;    // 0 = missing
+    uint64 parent_id;   // 0 = missing
   };
   struct ThreadInfo {
     int32 tid;

--- a/tensorflow/core/profiler/lib/BUILD
+++ b/tensorflow/core/profiler/lib/BUILD
@@ -58,6 +58,7 @@ tf_cuda_library(
         "//tensorflow/core:lib",
         "//tensorflow/core/profiler/internal:traceme_recorder",
         "@com_google_absl//absl/strings",
+        "//tensorflow/core/platform:annotation"
     ],
 )
 

--- a/tensorflow/core/profiler/lib/traceme.cc
+++ b/tensorflow/core/profiler/lib/traceme.cc
@@ -18,17 +18,6 @@ limitations under the License.
 namespace tensorflow {
 namespace profiler {
 
-// Move to tensorflow::tracing::CallingContext in annotation.h
-// // Activity IDs: To avoid contention over a counter, the top 32 bits identify
-// // the originating thread, the bottom 32 bits name the event within a thread.
-// // IDs may be reused after 4 billion events on one thread, or 4 billion threads.
-// static std::atomic<uint32> thread_counter(1);  // avoid kUntracedActivity
-// uint64 NewActivityId() {
-//   const thread_local static uint32 thread_id = thread_counter.fetch_add(1);
-//   thread_local static uint32 per_thread_activity_id = 0;
-//   return static_cast<uint64>(thread_id) << 32 | per_thread_activity_id++;
-// }
-
 /* static */ uint64 TraceMe::ActivityStartImpl(
     absl::string_view activity_name) {
   uint64 parent_id = tracing::CallingContext::GetCurrentContext();

--- a/tensorflow/core/profiler/lib/traceme.cc
+++ b/tensorflow/core/profiler/lib/traceme.cc
@@ -18,28 +18,32 @@ limitations under the License.
 namespace tensorflow {
 namespace profiler {
 
-// Activity IDs: To avoid contention over a counter, the top 32 bits identify
-// the originating thread, the bottom 32 bits name the event within a thread.
-// IDs may be reused after 4 billion events on one thread, or 4 billion threads.
-static std::atomic<uint32> thread_counter(1);  // avoid kUntracedActivity
-uint64 NewActivityId() {
-  const thread_local static uint32 thread_id = thread_counter.fetch_add(1);
-  thread_local static uint32 per_thread_activity_id = 0;
-  return static_cast<uint64>(thread_id) << 32 | per_thread_activity_id++;
-}
+// Move to tensorflow::tracing::CallingContext in annotation.h
+// // Activity IDs: To avoid contention over a counter, the top 32 bits identify
+// // the originating thread, the bottom 32 bits name the event within a thread.
+// // IDs may be reused after 4 billion events on one thread, or 4 billion threads.
+// static std::atomic<uint32> thread_counter(1);  // avoid kUntracedActivity
+// uint64 NewActivityId() {
+//   const thread_local static uint32 thread_id = thread_counter.fetch_add(1);
+//   thread_local static uint32 per_thread_activity_id = 0;
+//   return static_cast<uint64>(thread_id) << 32 | per_thread_activity_id++;
+// }
 
 /* static */ uint64 TraceMe::ActivityStartImpl(
     absl::string_view activity_name) {
-  uint64 activity_id = NewActivityId();
+  uint64 parent_id = tracing::CallingContext::GetCurrentContext();
+  uint64 activity_id = tracing::CallingContext::GetAndPush();
   TraceMeRecorder::Record({activity_id, string(activity_name),
                            /*start_time=*/EnvTime::Default()->NowNanos(),
-                           /*end_time=*/0});
+                           /*end_time=*/0, /*parent_id=*/parent_id});
   return activity_id;
 }
 
 /* static */ void TraceMe::ActivityEndImpl(uint64 activity_id) {
+  tracing::CallingContext::Pop();
   TraceMeRecorder::Record({activity_id, /*name=*/"", /*start_time=*/0,
-                           /*end_time=*/EnvTime::Default()->NowNanos()});
+                           /*end_time=*/EnvTime::Default()->NowNanos(),
+                           /*parent_id=*/0});
 }
 
 }  // namespace profiler

--- a/tensorflow/python/client/timeline.py
+++ b/tensorflow/python/client/timeline.py
@@ -434,6 +434,8 @@ class Timeline(object):
 
   def _assign_lanes(self, device_only):
     """Assigns non-overlapping lanes for the activities on each device."""
+    cpu_tid_assign = 0
+    cpu_tid_map = {}
     for device_stats in self._step_stats.dev_stats:
       device_name = device_stats.device
       is_gputrace = self._is_gputrace_device(device_name)
@@ -452,6 +454,14 @@ class Timeline(object):
             l = len(lanes)
             lanes.append(ns.all_start_micros + ns.all_end_rel_micros)
           ns.thread_id = l
+      else:
+        for ns in device_stats.node_stats:
+          if ns.thread_id not in cpu_tid_map.keys():
+            cpu_tid_map[ns.thread_id] = cpu_tid_assign
+            ns.thread_id = cpu_tid_assign
+            cpu_tid_assign = cpu_tid_assign + 1
+          else:
+            ns.thread_id = cpu_tid_map[ns.thread_id]
 
   def _emit_op(self, nodestats, pid, is_gputrace, is_hosttrace, activity_cache):
     """Generates a Chrome Trace event to show Op execution.

--- a/tensorflow/python/training/basic_session_run_hooks.py
+++ b/tensorflow/python/training/basic_session_run_hooks.py
@@ -1029,7 +1029,7 @@ class ProfilerHook(session_run_hook.SessionRunHook):
                output_dir="",
                show_dataflow=True,
                show_memory=False,
-               use_real_thread_id=False):
+               use_real_thread_id=True):
     """Initializes a hook that takes periodic profiling snapshots.
 
     `options.run_metadata` argument of `tf.Session.Run` is used to collect
@@ -1047,6 +1047,8 @@ class ProfilerHook(session_run_hook.SessionRunHook):
         producers and consumers of tensors.
       show_memory: `bool`, if True, add object snapshot events to the trace
         showing the sizes and lifetimes of tensors.
+      use_real_thread_id: `bool`, if True, use real collected thread id instead
+        of generating fake thread id for concurrent events.
     """
     self._output_file = os.path.join(output_dir, "timeline-{}.json")
     self._file_writer = SummaryWriterCache.get(output_dir)


### PR DESCRIPTION
1. Fix unknown ops shown in the timeline
2. Add kernel launch event traces and correlations
3. enable calling context collections and corresponding attributions in the timeline events
4. Use uniformed thread id (begin from 1) for posix environments and enable the use_real_thread_id flag by default for more genuine timelines shown in google chrome tracing tools.

--------
# Before this PR:
- Many "unknown" ops and kernel executions without limited information.
- No launching events with latency metrics
- No Calling context attributions to seek which op launches the kernels or ops
- No invoke flows to indicate which op invokes a op or a kernel;
- Bad thread id attributions to see the real thread concurrencies;
![image](https://user-images.githubusercontent.com/17382952/182345864-04414030-c8d0-4ab5-8948-4ef120bf6a17.png)
![image](https://user-images.githubusercontent.com/17382952/182346029-4981f98a-7c03-4898-a2d0-ecd3e892595c.png)

# In this PR:
I fix the `unknown` attributions in the timeline events, and introduce new `calling context` attributes in the event descriptions, `/host:CPU Launch` panels to show all kernel launching events with corresponding launch latency attributions, `invoke` flows to indicate the invoking ops (the source op invokes the designated op), and `kernel launch` flows to indicate the correlations of kernel launch events and corresponding kernel execution events. The modified timeline is shown as follows:
![image](https://user-images.githubusercontent.com/17382952/182347889-f2d3d342-33a4-4cd3-b215-937b4231a8c9.png)
![image](https://user-images.githubusercontent.com/17382952/182348087-11ebbd7d-f7bd-4570-afca-c19e50b5dde8.png)
![image](https://user-images.githubusercontent.com/17382952/182347698-c06c5888-eacb-432f-9b89-50e1d948e8dc.png)

