### PR TITLE
[Distributed] Remove user packet split to avoid multiple user packet out-of-order issue.

### DIFF
--- a/tensorflow/contrib/star/seastar/seastar_client_tag.cc
+++ b/tensorflow/contrib/star/seastar/seastar_client_tag.cc
@@ -135,14 +135,6 @@ std::vector<seastar::user_packet*> SeastarClientTag::ToUserPacketWithTensors() {
   total_len += req_body_buf_.len_;
 
   for (int i = 0; i < req_tensor_count_; ++i) {
-    if (frags.size() > IOV_MAX / 2) {
-      std::swap(up->_fragments, frags);
-
-      up->_done = []() {};
-      ret.emplace_back(up);
-      up = new seastar::user_packet;
-    }
-
     frags.emplace_back(seastar::net::fragment {req_message_bufs_[i].data_,
           req_message_bufs_[i].len_});
     total_len += req_message_bufs_[i].len_;

--- a/tensorflow/contrib/star/seastar/seastar_server_tag.cc
+++ b/tensorflow/contrib/star/seastar/seastar_server_tag.cc
@@ -48,13 +48,6 @@ std::vector<seastar::user_packet*> SeastarServerTag::ToUserPacketWithTensors() {
   // For fuse recv / zero copy run graph, if error happens 'resp_tensor_count_'
   // is zero as when it is inited, so no tensor can be sent.
   for (auto i = 0; i < resp_tensor_count_; ++i) {
-    if (frags.size() > IOV_MAX / 2) {
-      std::swap(up->_fragments, frags);
-
-      up->_done = []() {};
-      ret.emplace_back(up);
-      up = new seastar::user_packet;
-    }
     frags.emplace_back(seastar::net::fragment {resp_message_bufs_[i].data_,
         resp_message_bufs_[i].len_});
     total_len += resp_message_bufs_[i].len_;


### PR DESCRIPTION
- when concurrent session.run,
  out-of-order write on same fd may happen with concurrent multi user packets rpc requests
- with support for large user packet write by pollable_fd::write_some,
  no need to split one rpc request into multi user packets