### PR TITLE
[Grappler] Fix the 'NodeIsInGpu is not declare' issue

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -1552,7 +1552,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     TF_CHECK_OK(GetNodeAttr(n->def(), "transpose_a", &trans_a));
 
     // Do not Fuse Matmul which gpu op not implemented.
-    if (NodeIsOnGpu(n->node())) {
+    if(grappler::NodeIsOnGpu(&(n->def()))) {
       return false;
     }
 

--- a/tensorflow/core/graph/mkl_layout_pass.h
+++ b/tensorflow/core/graph/mkl_layout_pass.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/core/util/env_var.h"
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/lib/gtl/flatset.h"
+#include "tensorflow/core/grappler/utils.h"
 
 namespace tensorflow {
 // Interface to invoke the pass for unit test


### PR DESCRIPTION
Fix following issue occurred when compling.
```
ERROR: /whl_build/repo/ali_DeepRec/DeepRec/tensorflow/core/BUILD:3367:1: C++ compilation of rule '//tensorflow/core:core_cpu_impl' failed (Exit 1): gcc failed: error executing command
  (cd /root/.cache/bazel/_bazel_root/31d1ea751fd7ccbf446ae91732fb258b/execroot/org_tensorflow && \
  exec env - \
    LD_LIBRARY_PATH=/home/pai/lib: \
    PATH=/home/pai/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
    PWD=/proc/self/cwd \
  /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections -fdata-sections '-std=c++0x' -I/home/pai/include -I/root/.cache/bazel/_bazel_root/31d1ea751fd7ccbf446ae91732fb258b/external/local_config_cc -MD -MF bazel-out/host/bin/tensorflow/core/_objs/core_cpu_impl/mkl_layout_pass.pic.d '-frandom-seed=bazel-out/host/bin/tensorflow/core/_objs/core_cpu_impl/mkl_layout_pass.pic.o' -fPIC -D__CLANG_SUPPORT_DYN_ANNOTATION__ -DEIGEN_MPL2_ONLY '-DEIGEN_MAX_ALIGN_BYTES=64' '-DEIGEN_HAS_TYPE_TRAITS=0' -DTF_USE_SNAPPY -DTENSORFLOW_USE_STAR -DLEVELDB_PLATFORM_POSIX -iquote . -iquote bazel-out/host/bin -iquote external/com_google_absl -iquote bazel-out/host/bin/external/com_google_absl -iquote external/nsync -iquote bazel-out/host/bin/external/nsync -iquote external/eigen_archive -iquote bazel-out/host/bin/external/eigen_archive -iquote external/local_config_sycl -iquote bazel-out/host/bin/external/local_config_sycl -iquote external/gif_archive -iquote bazel-out/host/bin/external/gif_archive -iquote external/jpeg -iquote bazel-out/host/bin/external/jpeg -iquote external/com_google_protobuf -iquote bazel-out/host/bin/external/com_google_protobuf -iquote external/com_googlesource_code_re2 -iquote bazel-out/host/bin/external/com_googlesource_code_re2 -iquote external/farmhash_archive -iquote bazel-out/host/bin/external/farmhash_archive -iquote external/fft2d -iquote bazel-out/host/bin/external/fft2d -iquote external/highwayhash -iquote bazel-out/host/bin/external/highwayhash -iquote external/zlib_archive -iquote bazel-out/host/bin/external/zlib_archive -iquote external/sparsehash_c11 -iquote bazel-out/host/bin/external/sparsehash_c11 -iquote external/com_github_google_leveldb -iquote bazel-out/host/bin/external/com_github_google_leveldb -iquote external/nvtx_archive -iquote bazel-out/host/bin/external/nvtx_archive -Ibazel-out/host/bin/external/nvtx_archive/_virtual_includes/nvtx -isystem external/nsync/public -isystem bazel-out/host/bin/external/nsync/public -isystem third_party/eigen3/mkl_include -isystem bazel-out/host/bin/third_party/eigen3/mkl_include -isystem external/eigen_archive -isystem bazel-out/host/bin/external/eigen_archive -isystem external/gif_archive -isystem bazel-out/host/bin/external/gif_archive -isystem external/com_google_protobuf/src -isystem bazel-out/host/bin/external/com_google_protobuf/src -isystem external/farmhash_archive/src -isystem bazel-out/host/bin/external/farmhash_archive/src -isystem external/zlib_archive -isystem bazel-out/host/bin/external/zlib_archive -isystem external/sparsehash_c11 -isystem bazel-out/host/bin/external/sparsehash_c11 -isystem external/com_github_google_leveldb/include -isystem bazel-out/host/bin/external/com_github_google_leveldb/include -g0 -g0 '-std=c++14' -DEIGEN_AVOID_STL_ARRAY -Iexternal/gemmlowp -Wno-sign-compare '-ftemplate-depth=900' -fno-exceptions '-DGOOGLE_NCCL=1' '-DINTEL_MKL=1' -DINTEL_MKL_DNN_ONLY -DENABLE_DNNL_THREADPOOL -DENABLE_MKL -msse3 -pthread -fopenmp -fno-openmp '-DINTEL_MKL=1' -DINTEL_MKL_DNN_ONLY -DENABLE_MKL '-DGOOGLE_NCCL=1' -fno-canonical-system-headers -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -c tensorflow/core/graph/mkl_layout_pass.cc -o bazel-out/host/bin/tensorflow/core/_objs/core_cpu_impl/mkl_layout_pass.pic.o)
Execution platform: @bazel_tools//platforms:host_platform
tensorflow/core/graph/mkl_layout_pass.cc: In static member function 'static bool tensorflow::MklLayoutRewritePass::FusedMatMulRewrite(const tensorflow::Node*)':
tensorflow/core/graph/mkl_layout_pass.cc:1555:24: error: 'const class tensorflow::Node' has no member named 'node'; did you mean 'Node'?
     if (NodeIsOnGpu(n->node())) {
                        ^~~~
                        Node
tensorflow/core/graph/mkl_layout_pass.cc:1555:9: error: 'NodeIsOnGpu' was not declared in this scope
     if (NodeIsOnGpu(n->node())) {
         ^~~~~~~~~~~
tensorflow/core/graph/mkl_layout_pass.cc:1555:9: note: suggested alternative: 'NodeOutput'
     if (NodeIsOnGpu(n->node())) {
         ^~~~~~~~~~~
         NodeOutput
Target //tensorflow/tools/pip_package:build_pip_package failed to build
ERROR: /whl_build/repo/ali_DeepRec/DeepRec/tensorflow/python/BUILD:5178:1 C++ compilation of rule '//tensorflow/core:core_cpu_impl' failed (Exit 1): gcc failed: error executing command
  (cd /root/.cache/bazel/_bazel_root/31d1ea751fd7ccbf446ae91732fb258b/execroot/org_tensorflow && \
  exec env - \
    LD_LIBRARY_PATH=/home/pai/lib: \
    PATH=/home/pai/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
    PWD=/proc/self/cwd \
  /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections -fdata-sections '-std=c++0x' -I/home/pai/include -I/root/.cache/bazel/_bazel_root/31d1ea751fd7ccbf446ae91732fb258b/external/local_config_cc -MD -MF bazel-out/host/bin/tensorflow/core/_objs/core_cpu_impl/mkl_layout_pass.pic.d '-frandom-seed=bazel-out/host/bin/tensorflow/core/_objs/core_cpu_impl/mkl_layout_pass.pic.o' -fPIC -D__CLANG_SUPPORT_DYN_ANNOTATION__ -DEIGEN_MPL2_ONLY '-DEIGEN_MAX_ALIGN_BYTES=64' '-DEIGEN_HAS_TYPE_TRAITS=0' -DTF_USE_SNAPPY -DTENSORFLOW_USE_STAR -DLEVELDB_PLATFORM_POSIX -iquote . -iquote bazel-out/host/bin -iquote external/com_google_absl -iquote bazel-out/host/bin/external/com_google_absl -iquote external/nsync -iquote bazel-out/host/bin/external/nsync -iquote external/eigen_archive -iquote bazel-out/host/bin/external/eigen_archive -iquote external/local_config_sycl -iquote bazel-out/host/bin/external/local_config_sycl -iquote external/gif_archive -iquote bazel-out/host/bin/external/gif_archive -iquote external/jpeg -iquote bazel-out/host/bin/external/jpeg -iquote external/com_google_protobuf -iquote bazel-out/host/bin/external/com_google_protobuf -iquote external/com_googlesource_code_re2 -iquote bazel-out/host/bin/external/com_googlesource_code_re2 -iquote external/farmhash_archive -iquote bazel-out/host/bin/external/farmhash_archive -iquote external/fft2d -iquote bazel-out/host/bin/external/fft2d -iquote external/highwayhash -iquote bazel-out/host/bin/external/highwayhash -iquote external/zlib_archive -iquote bazel-out/host/bin/external/zlib_archive -iquote external/sparsehash_c11 -iquote bazel-out/host/bin/external/sparsehash_c11 -iquote external/com_github_google_leveldb -iquote bazel-out/host/bin/external/com_github_google_leveldb -iquote external/nvtx_archive -iquote bazel-out/host/bin/external/nvtx_archive -Ibazel-out/host/bin/external/nvtx_archive/_virtual_includes/nvtx -isystem external/nsync/public -isystem bazel-out/host/bin/external/nsync/public -isystem third_party/eigen3/mkl_include -isystem bazel-out/host/bin/third_party/eigen3/mkl_include -isystem external/eigen_archive -isystem bazel-out/host/bin/external/eigen_archive -isystem external/gif_archive -isystem bazel-out/host/bin/external/gif_archive -isystem external/com_google_protobuf/src -isystem bazel-out/host/bin/external/com_google_protobuf/src -isystem external/farmhash_archive/src -isystem bazel-out/host/bin/external/farmhash_archive/src -isystem external/zlib_archive -isystem bazel-out/host/bin/external/zlib_archive -isystem external/sparsehash_c11 -isystem bazel-out/host/bin/external/sparsehash_c11 -isystem external/com_github_google_leveldb/include -isystem bazel-out/host/bin/external/com_github_google_leveldb/include -g0 -g0 '-std=c++14' -DEIGEN_AVOID_STL_ARRAY -Iexternal/gemmlowp -Wno-sign-compare '-ftemplate-depth=900' -fno-exceptions '-DGOOGLE_NCCL=1' '-DINTEL_MKL=1' -DINTEL_MKL_DNN_ONLY -DENABLE_DNNL_THREADPOOL -DENABLE_MKL -msse3 -pthread -fopenmp -fno-openmp '-DINTEL_MKL=1' -DINTEL_MKL_DNN_ONLY -DENABLE_MKL '-DGOOGLE_NCCL=1' -fno-canonical-system-headers -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -c tensorflow/core/graph/mkl_layout_pass.cc -o bazel-out/host/bin/tensorflow/core/_objs/core_cpu_impl/mkl_layout_pass.pic.o)
Execution platform: @bazel_tools//platforms:host_platform
INFO: Elapsed time: 21.602s, Critical Path: 10.64s
INFO: 12 processes: 12 local.
FAILED: Build did NOT complete successfully
```