### PR TITLE
[Serving] Fix serving_processor compile issue.

### DIFF
--- a/serving/processor/serving/BUILD
+++ b/serving/processor/serving/BUILD
@@ -51,6 +51,8 @@ cc_library(
         "//tensorflow/core:framework",
         "//tensorflow/core:core_cpu",
         "//tensorflow/cc/saved_model:loader",
+        "//tensorflow/cc/saved_model:reader",
+        "//tensorflow/cc/saved_model:constants",
         "//tensorflow/cc/saved_model:signature_constants",
         "//tensorflow/cc/saved_model:tag_constants",
         ],

--- a/serving/processor/storage/BUILD
+++ b/serving/processor/storage/BUILD
@@ -74,10 +74,12 @@ cc_library(
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/cc/saved_model:loader",
+        "//tensorflow/cc/saved_model:reader",
+        "//tensorflow/cc/saved_model:constants",
         "//serving/processor/framework:model_version",
         "//serving/processor/framework/filesystem:oss_filesystem",
         "//serving/processor/serving:model_config",
-        "feature_store_mgr",
+        ":feature_store_mgr",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -492,6 +492,7 @@ package_group(
         "//tensorflow_estimator/python/estimator/...",
         "//tensorflow_models/official/...",
         "//third_party/py/autograph/...",
+        "//serving/...",
     ],
 )
 


### PR DESCRIPTION
```shell
$ bazel build //serving/processor/serving:libserving_processor.so
...
ERROR: /home/marvin/workspace/DeepRec/serving/processor/serving/BUILD:25:1: in cc_binary rule //serving/processor/serving:libserving_processor.so: target '//tensorflow:libtensorflow_framework.so' is not visible from target '//serving/processor/serving:libserving_processor.so'. Check the visibility declaration of the former target if you think the dependency is legitimate
ERROR: /home/marvin/workspace/DeepRec/serving/processor/serving/BUILD:25:1: in cc_binary rule //serving/processor/serving:libserving_processor.so: target '//tensorflow:libtensorflow_framework.so.1' is not visible from target '//serving/processor/serving:libserving_processor.so'. Check the visibility declaration of the former target if you think the dependency is legitimate
ERROR: /home/marvin/workspace/DeepRec/serving/processor/serving/BUILD:25:1: in cc_binary rule //serving/processor/serving:libserving_processor.so: target '//tensorflow:libtensorflow_framework.so.1' is not visible from target '//serving/processor/serving:libserving_processor.so'. Check the visibility declaration of the former target if you think the dependency is legitimate
...
```