### PR TITLE
add virtual dtor to BatchCache

### DIFF
--- a/tensorflow/core/framework/embedding/cache.h
+++ b/tensorflow/core/framework/embedding/cache.h
@@ -18,6 +18,7 @@ template <class K>
 class BatchCache {
  public:
   BatchCache() {}
+  virtual ~BatchCache() {}
   void add_to_rank(const Tensor& t) {
     add_to_rank((K*)t.data(), t.NumElements());
   }


### PR DESCRIPTION
fix warning: 
`deleting object of abstract class type 'tensorflow::embedding::BatchCache<int>' which has non-virtual destructor will cause undefined behavior`