### PR TITLE
[Embedding] Remove useless code.

### DIFF
--- a/tensorflow/core/framework/embedding/multilevel_embedding.h
+++ b/tensorflow/core/framework/embedding/multilevel_embedding.h
@@ -218,10 +218,6 @@ class StorageManager {
     return sc_.path;
   }
 
-  int64 GertStorageSize() {
-    return sc_.size;
-  }
-
   bool IsMultiLevel() {
     return is_multi_level_;
   }


### PR DESCRIPTION
* fix compile for GCC12. Type of sc_.size is `std::vector<int64>`, not int64.
* `GertStorageSize()` is not used. 
