### PR TITLE
[Embedding] Preventing from accessing uninitialized data and fixing the invalid eviction when use HBM-DRAM storage of EmbeddingVariable.

### DIFF
--- a/tensorflow/core/framework/embedding/dram_leveldb_storage.h
+++ b/tensorflow/core/framework/embedding/dram_leveldb_storage.h
@@ -57,6 +57,21 @@ class DramLevelDBStore : public MultiTierStorage<K, V> {
     return s;
   }
 
+  void Insert(const std::vector<K>& keys,
+              ValuePtr<V>** value_ptrs) override{
+    for (size_t i = 0; i < keys.size(); i++) {
+      do {
+        Status s = dram_kv_->Insert(keys[i], value_ptrs[i]);
+        if (s.ok()) {
+          break;
+        } else {
+          (value_ptrs[i])->Destroy(alloc_);
+          delete value_ptrs[i];
+        }
+      } while (!(dram_kv_->Lookup(keys[i], &value_ptrs[i])).ok());
+    }
+  }
+
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size, CopyBackFlag &need_copyback) override {
     need_copyback = NOT_COPYBACK;

--- a/tensorflow/core/framework/embedding/dram_pmem_storage.h
+++ b/tensorflow/core/framework/embedding/dram_pmem_storage.h
@@ -59,6 +59,21 @@ class DramPmemStorage : public MultiTierStorage<K, V> {
     return s;
   }
 
+  void Insert(const std::vector<K>& keys,
+              ValuePtr<V>** value_ptrs) override{
+    for (size_t i = 0; i < keys.size(); i++) {
+      do {
+        Status s = dram_kv_->Insert(keys[i], value_ptrs[i]);
+        if (s.ok()) {
+          break;
+        } else {
+          (value_ptrs[i])->Destroy(dram_alloc_);
+          delete value_ptrs[i];
+        }
+      } while (!(dram_kv_->Lookup(keys[i], &value_ptrs[i])).ok());
+    }
+  }
+
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size, CopyBackFlag &need_copyback) override {
     need_copyback = NOT_COPYBACK;

--- a/tensorflow/core/framework/embedding/dram_ssd_storage.h
+++ b/tensorflow/core/framework/embedding/dram_ssd_storage.h
@@ -57,6 +57,21 @@ class DramSsdHashStorage : public MultiTierStorage<K, V> {
     return s;
   }
 
+  void Insert(const std::vector<K>& keys,
+              ValuePtr<V>** value_ptrs) override{
+    for (size_t i = 0; i < keys.size(); i++) {
+      do {
+        Status s = dram_kv_->Insert(keys[i], value_ptrs[i]);
+        if (s.ok()) {
+          break;
+        } else {
+          (value_ptrs[i])->Destroy(alloc_);
+          delete value_ptrs[i];
+        }
+      } while (!(dram_kv_->Lookup(keys[i], &value_ptrs[i])).ok());
+    }
+  }
+
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size, CopyBackFlag &need_copyback) override {
     need_copyback = NOT_COPYBACK;

--- a/tensorflow/core/framework/embedding/hbm_dram_storage.h
+++ b/tensorflow/core/framework/embedding/hbm_dram_storage.h
@@ -58,6 +58,21 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
     return s;
   }
 
+  void Insert(const std::vector<K>& keys,
+              ValuePtr<V>** value_ptrs) override {
+    for (size_t i = 0; i < keys.size(); i++) {
+      do {
+        Status s = hbm_kv_->Insert(keys[i], value_ptrs[i]);
+        if (s.ok()) {
+          break;
+        } else {
+          (value_ptrs[i])->Destroy(gpu_alloc_);
+          delete value_ptrs[i];
+        }
+      } while (!(hbm_kv_->Lookup(keys[i], &value_ptrs[i])).ok());
+    }
+  }
+
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size) override {
     Status s = hbm_kv_->Lookup(key, value_ptr);
@@ -130,7 +145,6 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
         copyback_cursor[j] = i;
         gpu_value_ptrs[j] = gpu_value_ptr;
         j++;
-        hbm_kv_->Insert(keys[i], gpu_value_ptr);
       }
     }
 

--- a/tensorflow/core/framework/embedding/storage.h
+++ b/tensorflow/core/framework/embedding/storage.h
@@ -55,6 +55,8 @@ class Storage {
   TF_DISALLOW_COPY_AND_ASSIGN(Storage);
 
   virtual Status Get(K key, ValuePtr<V>** value_ptr) = 0;
+  virtual void Insert(const std::vector<K>& keys,
+                        ValuePtr<V>** value_ptrs) = 0;
   virtual void SetAllocLen(int64 value_len, int slot_num) = 0;
   virtual Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size) = 0;

--- a/tensorflow/core/framework/embedding/storage_manager.h
+++ b/tensorflow/core/framework/embedding/storage_manager.h
@@ -102,6 +102,11 @@ class StorageManager {
     return storage_->Get(key, value_ptr);
   }
 
+  void Insert(const std::vector<K>& keys,
+                ValuePtr<V>** value_ptrs) {
+    storage_->Insert(keys, value_ptrs);
+  }
+
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr, size_t size) {
     return storage_->GetOrCreate(key, value_ptr, size);
   }

--- a/tensorflow/core/kernels/kv_variable_ops.h
+++ b/tensorflow/core/kernels/kv_variable_ops.h
@@ -232,7 +232,13 @@ Status DumpEmbeddingValues(EmbeddingVar<K, V>* ev,
         if (tot_valueptr_list[i] == reinterpret_cast<V*>(-1)) {
             // only forward, no backward, bypass
         } else if (tot_valueptr_list[i] == nullptr) {
-          key_filter_list_parts[partid].push_back(tot_key_list[i]);
+          if (filter_freq) {
+            key_filter_list_parts[partid].push_back(tot_key_list[i]);
+          } else {
+            key_list_parts[partid].push_back(tot_key_list[i]);
+            valueptr_list_parts[partid].push_back(
+                ev->GetDefaultValue(tot_key_list[i]));
+          }
         } else {
           key_list_parts[partid].push_back(tot_key_list[i]);
           valueptr_list_parts[partid].push_back(tot_valueptr_list[i]);

--- a/tensorflow/python/ops/embedding_variable_ops_test.py
+++ b/tensorflow/python/ops/embedding_variable_ops_test.py
@@ -2024,6 +2024,8 @@ class EmbeddingVariableTest(test_util.TensorFlowTestCase):
             else:
               self.assertEqual(result[i], 0)
 
+        sess.run([train_op], {ids:[3, 5]})
+        sess.run([train_op], {ids:[4]})
         r1 = sess.run(emb, {ids:[1,2,4,5]})
         r2 = sess.run(emb, {ids:[3]})
         r = r1.tolist() + r2.tolist()


### PR DESCRIPTION
Fix two bugs of HBM-DRAM storage:
1. Preventing from accessing uninitialized embeddings in asynchronous training.
2. Calling the Insert() interface when evict features causes data not to be updated.