### PR TITLE
[Debugability] Print stack trace for fatal logs

### DIFF
--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -126,10 +126,12 @@ cc_library(
     name = "logging",
     srcs = tf_platform_hdrs(["logging.h"]) + tf_platform_srcs(["logging.cc"]),
     hdrs = ["logging.h"],
+    linkopts = ["-ldl"],
     deps = [
         ":env_time",
         ":macros",
         ":platform",
+        ":stacktrace",
         ":types",
         "//tensorflow/core/platform/default/build_config:base",
     ] + tf_logging_absl_deps(),

--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow/core/platform/default/logging.h"
 #include "tensorflow/core/platform/env_time.h"
 #include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/platform/stacktrace.h"
 
 #if defined(PLATFORM_POSIX_ANDROID)
 #include <android/log.h>
@@ -106,6 +107,9 @@ void LogMessage::GenerateLogMessage() {
 
   fprintf(vlog_file.FilePtr(), "%s.%06d: %c %s:%d] %s\n", time_buffer,
           micros_remainder, "IWEF"[severity_], fname_, line_, str().c_str());
+  if (TF_PREDICT_FALSE(severity_ == FATAL)) {
+    fprintf(vlog_file.FilePtr(), "%s\n", tensorflow::CurrentStackTrace().c_str());
+  }
 }
 #endif
 


### PR DESCRIPTION
In many environment, generating core files is not allowed, which makes it hard to find the root cause of fatal log messages. This patch print stack trace for fatal logs