### PR TITLE
天池大赛代码审核

### DIFF
--- a/tensorflow/python/training/monitored_session.py
+++ b/tensorflow/python/training/monitored_session.py
@@ -620,6 +620,11 @@ def MonitoredTrainingSession(
   if config != None:
     # we only work for user pass in a not-null config, because for default config we can not determine some parameters
     config.graph_options.optimizer_options.do_smart_stage = True
+    config.graph_options.optimizer_options.do_op_fusion = True
+    os.environ['TF DISABLE EV ALLOCATOR'] = '1'
+    os.environ['ENABLE_MEMORY_OPTIMIZATION'] = '0'
+    
+    '''
     origbs = get_graph_batch_size()
     print('batchsize', origbs) 
     oppath = os.getcwd()
@@ -637,7 +642,7 @@ def MonitoredTrainingSession(
       rewrite_graph_with_micro_batch(config, int(origbs / 4), 4)
     elif oppath.find('DLRM') > 0:
       rewrite_graph_with_micro_batch(config, int(origbs / 4), 4)
-      
+    '''   
   
 
   if worker_context:


### PR DESCRIPTION
两个优化：

1 mkl在天池的8核心ECS机器下会有性能负向优化，因此编译的时候使用默认的eigen来编译
```
 bazel build -c opt --config=opt //tensorflow/tools/pip_package:build_pip_package

```

2 所有模型全都默认打开smartstage

3 microbatch流水线

microbatch流水线是deeprec中已经包含的一个功能，事实证明这个功能的优化效果比较明显。在不能修改模型的前提下，在框架中自动 给这几个模型打开microbatch同时保证原始的batchsize不变化也即训练的总样本量不变化，做了如下工作：

1）在构图完成后，graph finialize之前，对图做修改
先遍历图拿出构图使用的batchsize，cr中get_graph_batch_size方法
再通过确定流水线条数（micro_batch_num），对batchsize做修改（cr中rewrite_graph_with_micro_batch），比如原始batchsize是512，流水线4条，那么新的batchsize是512/4=128,同时4条流水线，保证总batchsize一样。

2）不同的模型流水线条数不能完全设置成一样：
DIEN的流水线条数只能为2条，如果4条会导致 AUC偏低对不齐，原因还需要调查 
其它的模型除WDL均使用4条流水线
WDL在开启流水线后会hang住，经查为smartstage打开所导致。但是关闭smartstage会运行挂掉，原因未知，后续对这块再提个PR来修复

至于 怎么对不同的模型设置不同的microbatchnum，这里做了一些取巧，会通过运行路径获取模型名字进而做设置。

