### PR TITLE
[CIBUILD] Fix hwloc build error on alinux3.

### DIFF
--- a/third_party/hwloc/hwloc_fix.patch
+++ b/third_party/hwloc/hwloc_fix.patch
@@ -6,7 +6,7 @@ index 6e51aa4..f2e6ac4 100644
  #include <sys/param.h>
  #endif
  
-+#if defined(__GNUC__) && (__GNUC__ <= 10)
++#if defined(__GNUC__) && (__GNUC__ <= 9)
  #ifdef HAVE_SYS_SYSCTL_H
  #include <sys/sysctl.h>
  #endif


### PR DESCRIPTION
Fix hwloc build error. The reason is high version of GCC(>=10) with high version of linux kernel(>5.5).