### PR TITLE
[NV-TF] Sync commits with NV-TF2212

### DIFF
--- a/addons/triton/BUILD
+++ b/addons/triton/BUILD
@@ -14,5 +14,6 @@ cc_library(
         "//tensorflow/core:core",
         "//tensorflow/cc/saved_model:loader",
         "//tensorflow/cc/saved_model:tag_constants",
+        "//tensorflow/c:c_api",
     ],
 )

--- a/addons/triton/tensorflow_backend_tf.cc
+++ b/addons/triton/tensorflow_backend_tf.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 #if GOOGLE_CUDA
 #include "triton/tensorflow_backend_tf.h"
 
+#include "tensorflow/c/c_api.h"
 #include "tensorflow/cc/saved_model/loader.h"
 #include "tensorflow/cc/saved_model/tag_constants.h"
 #include "tensorflow/core/common_runtime/device.h"
@@ -1170,6 +1171,21 @@ TRITONTF_ModelInitialize(
     }
   }
 
+  return nullptr;
+}
+
+TRITONTF_Error*
+TRITONTF_LoadAndRegisterLibrary(const char* path)
+{
+  TF_Status* status = TF_NewStatus();
+  TF_Library* lib = TF_LoadLibrary(path, status);
+  TF_Code status_code = TF_GetCode(status);
+  std::string status_msg(TF_Message(status));
+  TF_DeleteStatus(status);
+  if (status_code != TF_OK) {
+    return TRITONTF_ErrorNew(status_msg);
+  }
+  
   return nullptr;
 }
 #endif

--- a/addons/triton/tensorflow_backend_tf.cc
+++ b/addons/triton/tensorflow_backend_tf.cc
@@ -56,12 +56,12 @@ TRITONTF_IOList* TRITONTF_IOListNew(
 void TRITONTF_IOListDelete(TRITONTF_IOList* list);
 
 // If TensorFlow status is non-OK, return the equivalent TRITONTF_Error
-#define RETURN_IF_TF_ERROR(TFS)                          \
-  do {                                                   \
-    const tensorflow::Status& status__ = (TFS);          \
-    if (status__.code() != 0) {                          \
+#define RETURN_IF_TF_ERROR(TFS)                           \
+  do {                                                    \
+    const tensorflow::Status& status__ = (TFS);           \
+    if (status__.code() != 0) {                           \
       return TRITONTF_ErrorNew(status__.error_message()); \
-    }                                                    \
+    }                                                     \
   } while (false)
 
 namespace {
@@ -462,6 +462,9 @@ class ModelImpl {
       const std::vector<std::string>& output_names,
       TRITONTF_TensorList** output_tensors);
 
+  // Run a single operation.
+  TRITONTF_Error* RunOp(const std::string& op_name);
+
  private:
   const std::string model_name_;
   std::unique_ptr<tensorflow::SavedModelBundle> bundle_;
@@ -592,6 +595,13 @@ ModelImpl::Run(
     }
   }
 
+  return nullptr;
+}
+
+TRITONTF_Error*
+ModelImpl::RunOp(const std::string& op_name)
+{
+  RETURN_IF_TF_ERROR(session_->Run({}, {}, {op_name}, nullptr));
   return nullptr;
 }
 
@@ -944,10 +954,12 @@ TRITONTF_ModelCreateFromSavedModel(
   std::unique_ptr<tensorflow::SavedModelBundle> bundle(
       new tensorflow::SavedModelBundle);
 
-  // If user does not specify a 'tag' in the configuration file, use 'serve' as default
+  // If user does not specify a 'tag' in the configuration file, use 'serve' as
+  // default
   std::unordered_set<std::string> saved_model_tags;
-  const std::string TAG_TO_USE = 
-      (strcmp(graph_tag, "") == 0) ? tensorflow::kSavedModelTagServe : graph_tag;
+  const std::string TAG_TO_USE = (strcmp(graph_tag, "") == 0)
+                                     ? tensorflow::kSavedModelTagServe
+                                     : graph_tag;
   saved_model_tags.insert(TAG_TO_USE);
 
   tensorflow::RunOptions run_options;
@@ -971,12 +983,12 @@ TRITONTF_ModelCreateFromSavedModel(
 
   // If user does not specify a 'signature_def' in the configuration file,
   // then use "serving_default" as default
-  const std::string SIGNATURE_DEF_KEY_TO_USE = 
+  const std::string SIGNATURE_DEF_KEY_TO_USE =
       (strcmp(signature_def, "") == 0) ? "serving_default" : signature_def;
   static const std::string INIT_OP_SIGNATURE_DEF_KEY("__saved_model_init_op");
   static const std::string TRAIN_OP_SIGNATURE_DEF_KEY("__saved_model_train_op");
-  auto sig_itr = bundle->meta_graph_def.signature_def().find(
-      SIGNATURE_DEF_KEY_TO_USE);
+  auto sig_itr =
+      bundle->meta_graph_def.signature_def().find(SIGNATURE_DEF_KEY_TO_USE);
   if (sig_itr == bundle->meta_graph_def.signature_def().end()) {
     // If default serving signature_def key is not found, maybe it is named
     // something else, use one that is neither init_op key nor train_op key
@@ -1002,8 +1014,8 @@ TRITONTF_ModelCreateFromSavedModel(
   // Collect the inputs...
   TRITONTF_IOList* inputs = nullptr;
   for (const auto& sin : def.inputs()) {
-    inputs =
-        TRITONTF_IOListNew(sin.first.c_str(), sin.second.name().c_str(), inputs);
+    inputs = TRITONTF_IOListNew(
+        sin.first.c_str(), sin.second.name().c_str(), inputs);
     TRITONTF_IO* io = inputs->io_;
 
     const TRITONTF_DataType dt = ConvertDataType(sin.second.dtype());
@@ -1131,8 +1143,9 @@ TRITONTF_ModelMakeCallable(
 
 TRITONTF_Error*
 TRITONTF_ModelRun(
-    TRITONTF_Model* model, TRITONTF_TensorList* input_tensors, size_t num_outputs,
-    const char** output_names, TRITONTF_TensorList** output_tensors)
+    TRITONTF_Model* model, TRITONTF_TensorList* input_tensors,
+    size_t num_outputs, const char** output_names,
+    TRITONTF_TensorList** output_tensors)
 {
   ModelImpl* m = reinterpret_cast<ModelImpl*>(model);
 
@@ -1142,5 +1155,21 @@ TRITONTF_ModelRun(
   }
 
   return m->Run(input_tensors, output_tensor_names, output_tensors);
+}
+
+TRITONTF_Error*
+TRITONTF_ModelInitialize(
+    TRITONTF_Model* model, size_t num_init_operations,
+    const char** init_operation_names)
+{
+  ModelImpl* m = reinterpret_cast<ModelImpl*>(model);
+  for (auto i = 0; i < num_init_operations; i++) {
+    TRITONTF_Error* err = m->RunOp(init_operation_names[i]);
+    if (err != nullptr) {
+      return err;
+    }
+  }
+
+  return nullptr;
 }
 #endif

--- a/addons/triton/tensorflow_backend_tf.h
+++ b/addons/triton/tensorflow_backend_tf.h
@@ -272,6 +272,11 @@ TRITONTF_EXPORT TRITONTF_Error* TRITONTF_ModelRun(
     TRITONTF_Model* model, TRITONTF_TensorList* input_tensors, size_t num_outputs,
     const char** output_names, TRITONTF_TensorList** output_tensors);
 
+// Initialize all the operations that do require initialization.
+TRITONTF_EXPORT TRITONTF_Error* TRITONTF_ModelInitialize(
+    TRITONTF_Model* model, size_t num_init_operations,
+    const char** init_operation_names);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/addons/triton/tensorflow_backend_tf.h
+++ b/addons/triton/tensorflow_backend_tf.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -276,6 +276,10 @@ TRITONTF_EXPORT TRITONTF_Error* TRITONTF_ModelRun(
 TRITONTF_EXPORT TRITONTF_Error* TRITONTF_ModelInitialize(
     TRITONTF_Model* model, size_t num_init_operations,
     const char** init_operation_names);
+
+// Load a library and register its ops/kernels.
+TRITONTF_EXPORT TRITONTF_Error* TRITONTF_LoadAndRegisterLibrary(
+    const char* path);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tensorflow/compiler/tests/depthwise_conv_op_test.py
+++ b/tensorflow/compiler/tests/depthwise_conv_op_test.py
@@ -532,7 +532,7 @@ class DepthwiseConv2DTest(xla_test.XLATestCase):
 
     gpu_value = _GetVal(use_xla=True)
     cpu_value = _GetVal(use_xla=False)
-    self.assertAllClose(cpu_value, gpu_value, rtol=1e-4, atol=1e-4)
+    self.assertAllClose(cpu_value, gpu_value, rtol=1e-4, atol=2e-4)
 
   def testDepthwiseConv2DFilterGradCompare(self):
     for index, (input_size, filter_size, output_size, stride,

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
@@ -463,6 +463,7 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheCuda(
 
     // Use assignment instead of brace-list to make GCC 4.9 happy.
     RunConvOptions options;
+    options.profile_result = &profile_result;
     options.algo_override = alg;
 
     // Warmup with first run.
@@ -475,7 +476,6 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheCuda(
     }
 
     // Second run provides reliable timings.
-    options.profile_result = &profile_result;
     launch_status =
         RunGpuConv(instr, absl::MakeSpan(operand_buffers), result_buffer,
                    &scratch_allocator, stream, options);

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -929,16 +929,16 @@ int64 MinSystemMemory(int64 available_memory, int cc_major) {
   // In the future we could be more sophisticated by using a table of devices.
   int64 min_system_memory;
   if (available_memory < (1LL << 31)) {
-    min_system_memory = 225 * 1024 * 1024;
+    min_system_memory = 225LL * 1024 * 1024;
   } else {
     if (cc_major <= 6) {
-      min_system_memory = 675 * 1024 * 1024;
+      min_system_memory = 675LL * 1024 * 1024;
     } else if (cc_major <= 7) {
-      min_system_memory = 1064 * 1024 * 1024;
+      min_system_memory = 1064LL * 1024 * 1024;
     } else if (cc_major <= 8) {
-      min_system_memory = 1800 * 1024 * 1024;
+      min_system_memory = 1800LL * 1024 * 1024;
     } else {
-      min_system_memory = 4096 * 1024 * 1024;
+      min_system_memory = 4096LL * 1024 * 1024;
     }
   }
 #if defined(__GNUC__) && defined(__OPTIMIZE__)
@@ -955,7 +955,7 @@ int64 MinSystemMemory(int64 available_memory, int cc_major) {
 #if defined(ANDROID_TEGRA)
   // 1GB system mem for NVIDIA Tegra devices since they use the same mem for
   // RAM and Video RAM
-  min_system_memory = 1 << 30;
+  min_system_memory = 1LL << 30;
 #endif
   return min_system_memory;
 }

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -923,7 +923,8 @@ int64 MinSystemMemory(int64 available_memory, int cc_major) {
   // Otherwise, depending on the capability version assign
   //  675MiB (for cuda_compute_capability <= 6.x) or
   // 1064MiB (for cuda_compute_capability <= 7.x) or
-  // 1600MiB (for cuda_compute_capability >= 8.x)
+  // 1800MiB (for cuda_compute_capability >= 8.x) or
+  // 4096MiB (for cuda_compute_capability >= 9.x)
   //
   // In the future we could be more sophisticated by using a table of devices.
   int64 min_system_memory;
@@ -934,8 +935,10 @@ int64 MinSystemMemory(int64 available_memory, int cc_major) {
       min_system_memory = 675 * 1024 * 1024;
     } else if (cc_major <= 7) {
       min_system_memory = 1064 * 1024 * 1024;
+    } else if (cc_major <= 8) {
+      min_system_memory = 1800 * 1024 * 1024;
     } else {
-      min_system_memory = 1600 * 1024 * 1024;
+      min_system_memory = 4096 * 1024 * 1024;
     }
   }
 #if defined(__GNUC__) && defined(__OPTIMIZE__)

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -921,7 +921,7 @@ int64 MinSystemMemory(int64 available_memory, int cc_major) {
   //
   // If the available_memory is < 2GiB, we allocate 225MiB to system memory.
   // Otherwise, depending on the capability version assign
-  //  675MiB (for cuda_compute_capability <= 6.x) or
+  //  715MiB (for cuda_compute_capability <= 6.x) or
   // 1064MiB (for cuda_compute_capability <= 7.x) or
   // 1800MiB (for cuda_compute_capability >= 8.x) or
   // 4096MiB (for cuda_compute_capability >= 9.x)
@@ -932,7 +932,7 @@ int64 MinSystemMemory(int64 available_memory, int cc_major) {
     min_system_memory = 225LL * 1024 * 1024;
   } else {
     if (cc_major <= 6) {
-      min_system_memory = 675LL * 1024 * 1024;
+      min_system_memory = 715LL * 1024 * 1024;
     } else if (cc_major <= 7) {
       min_system_memory = 1064LL * 1024 * 1024;
     } else if (cc_major <= 8) {

--- a/tensorflow/core/kernels/fractional_avg_pool_op.cc
+++ b/tensorflow/core/kernels/fractional_avg_pool_op.cc
@@ -43,6 +43,12 @@ class FractionalAvgPoolOp : public OpKernel {
     OP_REQUIRES(context, pooling_ratio_.size() == 4,
                 errors::InvalidArgument(
                     "pooling_ratio field must specify 4 dimensions"));
+    for (std::size_t i = 0; i < pooling_ratio_.size(); ++i) {
+      OP_REQUIRES(context, pooling_ratio_[i] >= 1,
+                  errors::InvalidArgument(
+                      "pooling_ratio cannot be smaller than 1, got: ",
+                      pooling_ratio_[i]));
+    }
     OP_REQUIRES(
         context, pooling_ratio_[0] == 1 || pooling_ratio_[3] == 1,
         errors::Unimplemented("Fractional average pooling is not yet "
@@ -80,6 +86,12 @@ class FractionalAvgPoolOp : public OpKernel {
     std::vector<int> output_size(tensor_in_and_out_dims);
     for (int i = 0; i < tensor_in_and_out_dims; ++i) {
       input_size[i] = tensor_in.dim_size(i);
+      OP_REQUIRES(
+          context, input_size[i] >= pooling_ratio_[i],
+          errors::InvalidArgument("Pooling ratio is higher than input "
+                                  "dimension size for dimension ",
+                                  i, ". Input dim size: ", input_size[i],
+                                  " pooling ratio: ", pooling_ratio_[i]));
     }
     // Output size.
     for (int i = 0; i < tensor_in_and_out_dims; ++i) {

--- a/tensorflow/core/kernels/fractional_max_pool_op.cc
+++ b/tensorflow/core/kernels/fractional_max_pool_op.cc
@@ -44,6 +44,12 @@ class FractionalMaxPoolOp : public OpKernel {
     OP_REQUIRES(context, pooling_ratio_.size() == 4,
                 errors::InvalidArgument("pooling_ratio field must "
                                         "specify 4 dimensions"));
+    for (std::size_t i = 0; i < pooling_ratio_.size(); ++i) {
+      OP_REQUIRES(context, pooling_ratio_[i] >= 1,
+                  errors::InvalidArgument(
+                      "pooling_ratio cannot be smaller than 1, got: ",
+                      pooling_ratio_[i]));
+    }
 
     OP_REQUIRES(
         context, pooling_ratio_[0] == 1 || pooling_ratio_[3] == 1,

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -59,6 +59,13 @@ Status FractionalPoolShapeFn(InferenceContext* c) {
     }
   }
 
+  for (std::size_t i = 0; i < pooling_ratio.size(); ++i) {
+    if (pooling_ratio[i] < 1) {
+      return errors::InvalidArgument(
+          "pooling_ratio cannot be smaller than 1, got: ", pooling_ratio[i]);
+    }
+  }
+
   c->set_output(0, c->MakeShape(output_dims));
   c->set_output(1, c->Vector(output_dims[1]));
   c->set_output(2, c->Vector(output_dims[2]));

--- a/tensorflow/core/ops/nn_ops_test.cc
+++ b/tensorflow/core/ops/nn_ops_test.cc
@@ -488,7 +488,8 @@ TEST(NNOpsTest, FractionalPool_ShapeFn) {
                        .Finalize(&op.node_def));
     };
 
-    set_op(std::vector<float>{2.0f, 1, 1 / 1.5f, 1 / 2.0f});
+    // pooling_ratio must >= 1.0
+    set_op(std::vector<float>{2.0f, 1, 1.5f, 4.0f});
 
     // Rank check.
     INFER_ERROR("must be rank 4", op, "[?,?,?]");
@@ -497,11 +498,11 @@ TEST(NNOpsTest, FractionalPool_ShapeFn) {
     INFER_OK(op, "?", "[?,?,?,?];[?];[?]");
     INFER_OK(op, "[?,?,?,?]", "[?,?,?,?];[?];[?]");
 
-    INFER_OK(op, "[10,20,30,40]", "[5,20,45,80];[20];[45]");
-    INFER_OK(op, "[?,20,30,40]", "[?,20,45,80];[20];[45]");
-    INFER_OK(op, "[10,?,30,40]", "[5,?,45,80];[?];[45]");
-    INFER_OK(op, "[10,20,?,40]", "[5,20,?,80];[20];[?]");
-    INFER_OK(op, "[10,20,30,?]", "[5,20,45,?];[20];[45]");
+    INFER_OK(op, "[10,20,30,40]", "[5,20,20,10];[20];[20]");
+    INFER_OK(op, "[?,20,30,40]", "[?,20,20,10];[20];[20]");
+    INFER_OK(op, "[10,?,30,40]", "[5,?,20,10];[?];[20]");
+    INFER_OK(op, "[10,20,?,40]", "[5,20,?,10];[20];[?]");
+    INFER_OK(op, "[10,20,30,?]", "[5,20,20,?];[20];[20]");
 
     // Wrong number of values for pooling_ratio.
     set_op(std::vector<float>{.5, 1.0, 1.5});

--- a/tensorflow/java/maven/proto/pom.xml
+++ b/tensorflow/java/maven/proto/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.16.1</version>
+      <version>3.16.3</version>
     </dependency>
   </dependencies>
 

--- a/tensorflow/java/maven/tensorflow-hadoop/pom.xml
+++ b/tensorflow/java/maven/tensorflow-hadoop/pom.xml
@@ -14,8 +14,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <hadoop.version>3.2.3</hadoop.version>
-        <protobuf.version>3.16.1</protobuf.version>
+        <hadoop.version>3.2.4</hadoop.version>
+        <protobuf.version>3.16.3</protobuf.version>
         <junit.version>4.13.1</junit.version>
     </properties>
 

--- a/tensorflow/lite/kernels/gather_nd.cc
+++ b/tensorflow/lite/kernels/gather_nd.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/c_api_internal.h"
+#include "tensorflow/lite/c/c_api_types.h"
 #include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
 #include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
@@ -94,13 +95,16 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 }
 
 template <typename ParamsT, typename IndicesT>
-TfLiteStatus GatherNd(const TfLiteTensor* params, const TfLiteTensor* indices,
-                      TfLiteTensor* output) {
-  reference_ops::GatherNd(
+TfLiteStatus GatherNd(TfLiteContext* context, const TfLiteTensor* params,
+                      const TfLiteTensor* indices, TfLiteTensor* output) {
+  const TfLiteStatus status = reference_ops::GatherNd(
       GetTensorShape(params), GetTensorData<ParamsT>(params),
       GetTensorShape(indices), GetTensorData<IndicesT>(indices),
       GetTensorShape(output), GetTensorData<ParamsT>(output));
-  return kTfLiteOk;
+  if (status != kTfLiteOk) {
+    TF_LITE_KERNEL_LOG(context, "gather_nd index out of bounds");
+  }
+  return status;
 }
 
 template <typename IndicesT>
@@ -108,15 +112,15 @@ TfLiteStatus EvalGatherNd(TfLiteContext* context, const TfLiteTensor* params,
                           const TfLiteTensor* indices, TfLiteTensor* output) {
   switch (params->type) {
     case kTfLiteFloat32:
-      return GatherNd<float, IndicesT>(params, indices, output);
+      return GatherNd<float, IndicesT>(context, params, indices, output);
     case kTfLiteUInt8:
-      return GatherNd<uint8_t, IndicesT>(params, indices, output);
+      return GatherNd<uint8_t, IndicesT>(context, params, indices, output);
     case kTfLiteInt8:
-      return GatherNd<int8_t, IndicesT>(params, indices, output);
+      return GatherNd<int8_t, IndicesT>(context, params, indices, output);
     case kTfLiteInt32:
-      return GatherNd<int32_t, IndicesT>(params, indices, output);
+      return GatherNd<int32_t, IndicesT>(context, params, indices, output);
     case kTfLiteInt64:
-      return GatherNd<int64_t, IndicesT>(params, indices, output);
+      return GatherNd<int64_t, IndicesT>(context, params, indices, output);
     default:
       context->ReportError(context,
                            "Params type '%s' are not supported by gather_nd.",

--- a/tensorflow/lite/kernels/gather_nd_test.cc
+++ b/tensorflow/lite/kernels/gather_nd_test.cc
@@ -68,6 +68,22 @@ TEST(GatherNdOpTest, ElementIndexingIntoMatrix) {
   EXPECT_THAT(m.GetOutput<float>(), ElementsAreArray({1.1, 2.2}));
 }
 
+TEST(GatherNdOpTest, ErrorOnOutOfBoundsTooLarge) {
+  GatherNdOpModel m({TensorType_FLOAT32, {2, 2}}, {TensorType_INT32, {2, 2}});
+  m.SetInput<float>({1.1, 1.2, 2.1, 2.2});
+  m.SetPositions<int32_t>({0, 0, 2, 0});
+  EXPECT_EQ(m.Invoke(), kTfLiteError);
+  m.SetPositions<int32_t>({0, 0, 1, 2});
+  EXPECT_EQ(m.Invoke(), kTfLiteError);
+}
+
+TEST(GatherNdOpTest, ErrorOnOutOfBoundsNegative) {
+  GatherNdOpModel m({TensorType_FLOAT32, {2, 2}}, {TensorType_INT32, {2, 2}});
+  m.SetInput<float>({1.1, 1.2, 2.1, 2.2});
+  m.SetPositions<int32_t>({1, -1, 1, 1});
+  EXPECT_EQ(m.Invoke(), kTfLiteError);
+}
+
 TEST(GatherNdOpTest, SliceIndexingIntoMatrix) {
   GatherNdOpModel m({TensorType_FLOAT32, {2, 2}}, {TensorType_INT32, {2, 1}});
   m.SetInput<float>({1.1, 1.2, 2.1, 2.2});

--- a/tensorflow/python/kernel_tests/fractional_avg_pool_op_test.py
+++ b/tensorflow/python/kernel_tests/fractional_avg_pool_op_test.py
@@ -337,6 +337,41 @@ class FractionalAvgTest(test.TestCase):
 
         self.evaluate(z)
 
+  def testPoolingRatioHasMoreDimThanInput(self):
+    with self.cached_session() as _:
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError,
+          r"Pooling ratio is higher than input dimension size for dimension 1.*"
+      ):
+        result = nn_ops.gen_nn_ops.fractional_avg_pool(
+            value=constant_op.constant(
+                value=[[[[1, 4, 2, 3]]]], dtype=dtypes.int64),
+            pooling_ratio=[1.0, 1.44, 1.73, 1.0],
+            pseudo_random=False,
+            overlapping=False,
+            deterministic=False,
+            seed=0,
+            seed2=0,
+            name=None)
+        self.evaluate(result)
+
+  def testPoolingRatioValueOutOfRange(self):
+    with self.cached_session() as _:
+      # Whether turn on `TF2_BEHAVIOR` generates different error messages
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError),
+          r"(pooling_ratio cannot be smaller than 1, got: .*)|(is negative)"):
+        result = nn_ops.gen_nn_ops.fractional_avg_pool(
+            value=np.zeros([3, 30, 30, 3]),
+            pooling_ratio=[1, -1, 3, 1],
+            pseudo_random=False,
+            overlapping=False,
+            deterministic=False,
+            seed=0,
+            seed2=0,
+        )
+        self.evaluate(result)
+
 
 class FractionalAvgPoolGradTest(test.TestCase):
   """Tests for FractionalAvgPoolGrad.

--- a/tensorflow/python/kernel_tests/fractional_max_pool_op_test.py
+++ b/tensorflow/python/kernel_tests/fractional_max_pool_op_test.py
@@ -326,6 +326,23 @@ class FractionalMaxPoolTest(test.TestCase):
             name=None)
         self.evaluate(result)
 
+  def testPoolingRatioValueOutOfRange(self):
+    with self.cached_session() as _:
+      # Whether turn on `TF2_BEHAVIOR` generates different error messages
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError),
+          r"(pooling_ratio cannot be smaller than 1, got: .*)|(is negative)"):
+        result = nn_ops.gen_nn_ops.fractional_max_pool(
+            value=np.zeros([3, 30, 30, 3]),
+            pooling_ratio=[1, -1, 3, 1],
+            pseudo_random=False,
+            overlapping=False,
+            deterministic=False,
+            seed=0,
+            seed2=0,
+        )
+        self.evaluate(result)
+
 
 class FractionalMaxPoolGradTest(test.TestCase):
   """Tests for FractionalMaxPoolGrad.

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -662,12 +662,12 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "zlib_archive",
         build_file = clean_dep("//third_party:zlib.BUILD"),
-        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-        strip_prefix = "zlib-1.2.11",
+        sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+        strip_prefix = "zlib-1.2.13",
         system_build_file = clean_dep("//third_party/systemlibs:zlib.BUILD"),
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/zlib.net/zlib-1.2.11.tar.gz",
-            "https://zlib.net/zlib-1.2.11.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/zlib.net/zlib-1.2.13.tar.gz",
+            "https://zlib.net/fossils/zlib-1.2.13.tar.gz",
         ],
     )
 

--- a/third_party/llvm/llvm.autogenerated.BUILD
+++ b/third_party/llvm/llvm.autogenerated.BUILD
@@ -3758,6 +3758,7 @@ cc_library(
     deps = [
         ":config",
         ":demangle",
+        "@zlib_archive//:zlib",
     ],
 )
 

--- a/third_party/png.BUILD
+++ b/third_party/png.BUILD
@@ -61,7 +61,7 @@ genrule(
     name = "snappy_stubs_public_h",
     srcs = ["scripts/pnglibconf.h.prebuilt"],
     outs = ["pnglibconf.h"],
-    cmd = "sed -e 's/PNG_ZLIB_VERNUM 0/PNG_ZLIB_VERNUM 0x12b0/' $< >$@",
+    cmd = "sed -e 's/PNG_ZLIB_VERNUM 0/PNG_ZLIB_VERNUM 0x12d0/' $< >$@",
 )
 
 config_setting(


### PR DESCRIPTION
1. (TRITON) Add support for initialize operations
2. Boost sysmem carveout on Hopper to 4GB.
3. Fix overflow issue in default sysmem carveout.
4. Bump up tollerance in DepthwiseConv2DTest to avoid intermittent test failures.
5. Bump java hadoop and protobuf versions
6. Fix CVE-2022-35937
7. Add warmup pass in XLA auto tuning.
8. Increase default sysmem carveout on Pascal to 715MB
9. Fix "did not memcpy host-to-deice" errors in L0_resnet tests
10. (TRITON) Add support for loading libraries - TF1
11. Fix CVE-2022-41900
12. Bump zlib to 1.2.13.
13. Configure LLVM to use TF's zlib_archive.