### PR TITLE
[ModelZoo] Disable GroupEmbedding and parquet_data in stock tensorflow model.

### DIFF
--- a/modelzoo/bst/train.py
+++ b/modelzoo/bst/train.py
@@ -398,7 +398,7 @@ def build_model_input(filename, batch_size, num_epochs):
     else:
         files = filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files,
                                                      fields = PARQUET_INPUT_COLUMN,
@@ -428,7 +428,7 @@ def build_feature_columns():
     item_column = []
     tag_column = []
     key_column = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in INPUT_FEATURES:
                 if column_name in TAG_COLUMN:
@@ -686,7 +686,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location + '/taobao_train_data'
     test_file = args.data_location + '/taobao_test_data'
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '.parquet'
         test_file += '.parquet'
     if (not os.path.exists(train_file)) or (not os.path.exists(test_file)):
@@ -694,7 +694,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/dbmtl/train.py
+++ b/modelzoo/dbmtl/train.py
@@ -343,7 +343,7 @@ def build_model_input(filename, batch_size, num_epochs):
     else:
         files = filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -364,7 +364,7 @@ def build_model_input(filename, batch_size, num_epochs):
 
 def build_feature_cols():
     feature_cols = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in ALL_FEATURE_COLUMNS:
                 if column_name in NOT_USED_CATEGORY:
@@ -639,7 +639,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location + '/taobao_train_data'
     test_file = args.data_location + '/taobao_test_data'
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '.parquet'
         test_file += '.parquet'
     if (not os.path.exists(train_file)) or (not os.path.exists(test_file)):
@@ -647,7 +647,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/dcn/train.py
+++ b/modelzoo/dcn/train.py
@@ -387,7 +387,7 @@ def build_model_input(filename, batch_size, num_epochs):
     else:
         files = filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -424,7 +424,7 @@ def build_feature_columns():
         return minmaxscaler
 
     emb_stacking_columns = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in FEATURE_COLUMNS:
                 if column_name in CATEGORICAL_COLUMNS:
@@ -668,7 +668,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location
     test_file = args.data_location
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '/train.parquet'
         test_file += '/eval.parquet'
     else:
@@ -679,7 +679,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/dcnv2/train.py
+++ b/modelzoo/dcnv2/train.py
@@ -403,7 +403,7 @@ def build_model_input(filename, batch_size, num_epochs):
     else:
         files = filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -440,7 +440,7 @@ def build_feature_columns():
         return minmaxscaler
 
     emb_stacking_columns = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in FEATURE_COLUMNS:
                 if column_name in CATEGORICAL_COLUMNS:
@@ -684,7 +684,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location
     test_file = args.data_location
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '/train.parquet'
         test_file += '/eval.parquet'
     else:
@@ -695,7 +695,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/deepfm/train.py
+++ b/modelzoo/deepfm/train.py
@@ -277,7 +277,7 @@ def build_model_input(filename, batch_size, num_epochs):
     else:
         files = filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -300,7 +300,7 @@ def build_feature_columns():
     wide_column = []
     deep_column = []
     fm_column = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in FEATURE_COLUMNS:
                 if column_name in CATEGORICAL_COLUMNS:
@@ -546,7 +546,7 @@ def main(tf_config=None, server=None):
     print('Checking dataset')
     train_file = args.data_location
     test_file = args.data_location
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '/train.parquet'
         test_file += '/eval.parquet'
     else:
@@ -557,7 +557,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/dien/train.py
+++ b/modelzoo/dien/train.py
@@ -641,7 +641,7 @@ def build_model_input(filename, neg_filename, batch_size, num_epochs):
         files = filename
         neg_files = neg_filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         dataset_neg_samples = parquet_dataset_ops.ParquetDataset(neg_files,
@@ -854,7 +854,7 @@ def main(tf_config=None, server=None):
     test_file = args.data_location + '/local_test_splitByUser'
     train_neg_file = train_file + '_neg'
     test_neg_file = test_file + '_neg'
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '.parquet'
         train_neg_file += '.parquet'
         test_file += '.parquet'
@@ -866,7 +866,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/din/train.py
+++ b/modelzoo/din/train.py
@@ -465,7 +465,7 @@ def build_model_input(filename, batch_size, num_epochs):
     else:
         files = filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -663,7 +663,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location + '/local_train_splitByUser'
     test_file = args.data_location + '/local_test_splitByUser'
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '.parquet'
         test_file += '.parquet'
     if (not os.path.exists(train_file)) or (not os.path.exists(test_file)):
@@ -672,7 +672,7 @@ def main(tf_config=None, server=None):
 
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/dlrm/train.py
+++ b/modelzoo/dlrm/train.py
@@ -317,7 +317,7 @@ def build_model_input(filename, batch_size, num_epochs):
         files = filename
 
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -340,7 +340,7 @@ def build_model_input(filename, batch_size, num_epochs):
 def build_feature_columns():
     dense_column = []
     sparse_column = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in FEATURE_COLUMNS:
                 if column_name in CATEGORICAL_COLUMNS:
@@ -581,7 +581,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location
     test_file = args.data_location
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '/train.parquet'
         test_file += '/eval.parquet'
     else:
@@ -592,7 +592,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/dssm/train.py
+++ b/modelzoo/dssm/train.py
@@ -294,7 +294,7 @@ def build_model_input(filename, batch_size, num_epochs):
     else:
         files = filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files,
                                                      fields = PARQUET_INPUT_COLUMN,
@@ -319,7 +319,7 @@ def build_model_input(filename, batch_size, num_epochs):
 def build_feature_columns():
     user_column = []
     item_column = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in INPUT_FEATURES:
                 categorical_column = tf.feature_column.categorical_column_with_hash_bucket(
@@ -552,7 +552,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location + '/taobao_train_data'
     test_file = args.data_location + '/taobao_test_data'
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '.parquet'
         test_file += '.parquet'
     if (not os.path.exists(train_file)) or (not os.path.exists(test_file)):
@@ -560,7 +560,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/esmm/train.py
+++ b/modelzoo/esmm/train.py
@@ -340,7 +340,7 @@ def build_model_input(filename, batch_size, num_epochs, seed, stock_tf, workqueu
         files = work_queue.input_dataset()
     else:
         files = filename
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -368,7 +368,7 @@ def build_feature_columns(stock_tf,
     user_column = []
     item_column = []
     combo_column = []
-    if args.embedding_column:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in ALL_FEATURE_COLUMNS:
                 column = tf.feature_column.categorical_column_with_hash_bucket(
@@ -605,7 +605,7 @@ def main(stock_tf, tf_config=None, server=None):
     print('Checking dataset...')
     train_file = args.data_location + '/taobao_train_data'
     test_file = args.data_location + '/taobao_test_data'
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '.parquet'
         test_file += '.parquet'
     if not os.path.exists(args.data_location):
@@ -617,7 +617,7 @@ def main(stock_tf, tf_config=None, server=None):
                          'in the given data_location. Please provide valid path')
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/masknet/train.py
+++ b/modelzoo/masknet/train.py
@@ -314,7 +314,7 @@ def build_model_input(filename, batch_size, num_epochs):
     else:
         files = filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -352,7 +352,7 @@ def build_feature_columns():
 
     deep_columns = []
     wide_columns = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in FEATURE_COLUMNS:
                 if column_name in CATEGORICAL_COLUMNS:
@@ -600,7 +600,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location
     test_file = args.data_location
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '/train.parquet'
         test_file += '/eval.parquet'
     else:
@@ -611,7 +611,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/mlperf/train.py
+++ b/modelzoo/mlperf/train.py
@@ -332,7 +332,7 @@ def build_model_input(filename, batch_size, num_epochs):
         files = filename
 
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -355,7 +355,7 @@ def build_model_input(filename, batch_size, num_epochs):
 def build_feature_columns():
     dense_column = []
     sparse_column = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in FEATURE_COLUMNS:
                 if column_name in CATEGORICAL_COLUMNS:
@@ -596,7 +596,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location
     test_file = args.data_location
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '/train.parquet'
         test_file += '/eval.parquet'
     else:
@@ -607,7 +607,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/mmoe/train.py
+++ b/modelzoo/mmoe/train.py
@@ -338,7 +338,7 @@ def build_model_input(filename, batch_size, num_epochs):
         files = filename
 
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -359,7 +359,7 @@ def build_model_input(filename, batch_size, num_epochs):
 # generate feature columns
 def build_feature_cols():
     feature_cols = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in ALL_FEATURE_COLUMNS:
                 if column_name in NOT_USED_CATEGORY:
@@ -635,7 +635,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location + '/taobao_train_data'
     test_file = args.data_location + '/taobao_test_data'
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '.parquet'
         test_file += '.parquet'
     if (not os.path.exists(train_file)) or (not os.path.exists(test_file)):
@@ -644,7 +644,7 @@ def main(tf_config=None, server=None):
     
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/ple/train.py
+++ b/modelzoo/ple/train.py
@@ -408,7 +408,7 @@ def build_model_input(filename, batch_size, num_epochs):
         files = filename
 
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -429,7 +429,7 @@ def build_model_input(filename, batch_size, num_epochs):
 # generate feature columns
 def build_feature_cols():
     feature_cols = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in ALL_FEATURE_COLUMNS:
                 if column_name in NOT_USED_CATEGORY:
@@ -705,7 +705,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location + '/taobao_train_data'
     test_file = args.data_location + '/taobao_test_data'
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '.parquet'
         test_file += '.parquet'
     if (not os.path.exists(train_file)) or (not os.path.exists(test_file)):
@@ -714,7 +714,7 @@ def main(tf_config=None, server=None):
     
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/simple_multitask/train.py
+++ b/modelzoo/simple_multitask/train.py
@@ -243,7 +243,7 @@ def build_model_input(filename, batch_size, num_epochs, seed, stock_tf, workqueu
         files = work_queue.input_dataset()
     else:
         files = filename
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -270,7 +270,7 @@ def build_feature_columns(stock_tf,
                           adaptive_emb=None,
                           dynamic_emb_var=None):
     feature_columns = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for i in range(len(HASH_INPUTS)):
                 column = tf.feature_column.categorical_column_with_hash_bucket(
@@ -498,7 +498,7 @@ def main(stock_tf, tf_config=None, server=None):
     print('Checking dataset...')
     train_file = args.data_location + '/taobao_train_data'
     test_file = args.data_location + '/taobao_test_data'
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '.parquet'
         test_file += '.parquet'
 
@@ -512,7 +512,7 @@ def main(stock_tf, tf_config=None, server=None):
 
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows

--- a/modelzoo/wide_and_deep/train.py
+++ b/modelzoo/wide_and_deep/train.py
@@ -320,7 +320,7 @@ def build_model_input(filename, batch_size, num_epochs):
     else:
         files = filename
     # Extract lines from input files using the Dataset API.
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         from tensorflow.python.data.experimental.ops import parquet_dataset_ops
         dataset = parquet_dataset_ops.ParquetDataset(files, batch_size=batch_size)
         if args.parquet_dataset_shuffle:
@@ -358,7 +358,7 @@ def build_feature_columns():
 
     deep_columns = []
     wide_columns = []
-    if args.group_embedding:
+    if args.group_embedding and not args.tf:
         with tf.feature_column.group_embedding_column_scope(name="categorical"):
             for column_name in FEATURE_COLUMNS:
                 if column_name in CATEGORICAL_COLUMNS:
@@ -607,7 +607,7 @@ def main(tf_config=None, server=None):
     print("Checking dataset...")
     train_file = args.data_location
     test_file = args.data_location
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         train_file += '/train.parquet'
         test_file += '/eval.parquet'
     else:
@@ -618,7 +618,7 @@ def main(tf_config=None, server=None):
         sys.exit()
     no_of_training_examples = 0
     no_of_test_examples = 0
-    if args.parquet_dataset:
+    if args.parquet_dataset and not args.tf:
         import pyarrow.parquet as pq
         no_of_training_examples = pq.read_table(train_file).num_rows
         no_of_test_examples = pq.read_table(test_file).num_rows


### PR DESCRIPTION
Disable GroupEmbedding and parquet_data with `--tf`, and fix a group_embedding issue in ESMM model.