### PR TITLE
[Embedding] Optimize cuda kernel implementation in GroupEmbedding.

### DIFF
--- a/docs/docs_en/Group-Embedding.md
+++ b/docs/docs_en/Group-Embedding.md
@@ -26,7 +26,7 @@ def group_embedding_lookup_sparse(params,
 - `sp_ids` : List | Tuple , SparseTensor sp_ids ​​is the ID used for EmbeddingLookup, the length must be consistent with params.
 - `combiners` : List | Tuple，The pooling method of embedding values.Currently support `mean` and `sum`.
 - `partition_strategy` : str，Currently not supported.
-- `sp_weights` : List | Typle the weight of sp_ids values.(Currently not supported.)
+- `sp_weights` : List | Typle the weight of sp_ids values.
 - `name` : str group name
 
 **group_embedding_column_scope**

--- a/docs/docs_zh/Group-Embedding.md
+++ b/docs/docs_zh/Group-Embedding.md
@@ -30,7 +30,7 @@ def group_embedding_lookup_sparse(params,
 - `sp_ids` : List | Tuple , SparseTensor ，values是用于查找的ID 长度必须和params保持一致
 - `combiners` : List | Tuple 查找完得到的embedding tensor聚合的方式，支持 `mean` 和 `sum`
 - `partition_strategy` : str 目前暂时不支持
-- `sp_weights` : List | Typle sp_ids 的 values 的权重。(目前暂时不支持，后续会开放)
+- `sp_weights` : List | Typle sp_ids 的 values 的权重。
 - `name` : str group的名称
 
 **group_embedding_column_scope**

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -5346,7 +5346,9 @@ tf_kernel_library(
 
 tf_kernel_library(
     name = "group_embedding_ops",
-    gpu_srcs = ["group_lookup_forward.cu.cc",
+    gpu_srcs = ["group_lookup_forward_base_ops.cu.h",
+                "group_lookup_backward_base_ops.cu.h",
+                "group_lookup_forward.cu.cc",
                 "group_lookup_backward.cu.cc",],
     deps = ["//third_party/eigen3",
             "//tensorflow/core/kernels:gpu_device_array",

--- a/tensorflow/core/kernels/group_lookup_backward.cu.cc
+++ b/tensorflow/core/kernels/group_lookup_backward.cu.cc
@@ -1,11 +1,8 @@
 /* Copyright 2022 The DeepRec Authors. All Rights Reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +24,7 @@ limitations under the License.
 #include "tensorflow/core/framework/resource_mgr.h"
 #include "tensorflow/core/framework/resource_var.h"
 #include "tensorflow/core/kernels/fused_embedding/fused_embedding_common.cu.h"
+#include "tensorflow/core/kernels/group_lookup_backward_base_ops.cu.h"
 #include "tensorflow/core/kernels/training_op_helpers.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/stream_executor/stream_executor.h"
@@ -35,189 +33,11 @@ namespace tensorflow {
 
 using GPUDevice = Eigen::GpuDevice;
 
-namespace {
-
-template <typename TKey, typename TValue>
-struct GroupEmbeddingBackWardArgs {
-  int nnz_;
-  int64_t emb_row_size_;
-  int *offset_indices_;
-  TValue *emb_variable_;
-  TValue *grads_;
-  TValue *grads_output_;
-  TKey *sp_values_;
-};
-
-template <typename TKey, typename TValue, Combiner combiner>
-__global__ void ComputeEVGradFn(
-    const int batch_size, const int dimension, const float max_norm,
-    const int num_lookups, GroupEmbeddingBackWardArgs<TKey, TValue> *args) {
-  __shared__ float l2_sum[1];
-
-  int bid = blockIdx.x;   // each block corresponding to one sample
-  int tid = threadIdx.x;  // each thread corresponding to one element in the
-                          // embedding vector
-
-  if (bid < batch_size && tid < dimension) {
-    for (int idx = 0; idx < num_lookups; ++idx) {
-      int value_offset = args[idx].offset_indices_[bid];
-      int feature_num;
-      if (blockIdx.x == int(batch_size) - 1) {
-        feature_num = args[idx].nnz_ - value_offset;
-      } else {
-        feature_num = args[idx].offset_indices_[bid + 1] - value_offset;
-      }
-      float grad = args[idx].grads_[bid * dimension + tid];
-      grad = CombineGrad<combiner>(grad, feature_num);
-
-      for (int j = 0; j < feature_num; ++j) {
-        float grad_i = grad;
-        int feature_offset = (value_offset + j) * dimension;
-        if (max_norm > 0.0f) {
-          float emb_element = 0.0f;  // TODO: hujunqi get emb_weight
-          if (threadIdx.x == 0) {
-            l2_sum[0] = 0.0f;
-          }
-          __syncthreads();
-          atomicAdd(l2_sum, emb_element * emb_element);
-          __syncthreads();
-          float l2_norm = sqrtf(l2_sum[0]);
-          if (l2_norm > max_norm) {
-            grad_i *= max_norm / l2_norm;
-          }
-        }
-        args[idx].grads_output_[(value_offset + j) * dimension + threadIdx.x] =
-            grad_i;
-      }
-    }
-  }
-}
-
-template <typename TKey, typename TValue, Combiner combiner>
-__global__ void ComputeSparseGradFn(
-    const int batch_size, const int dimension, const float max_norm,
-    const int num_lookups, GroupEmbeddingBackWardArgs<TKey, TValue> *args) {
-  __shared__ float l2_sum[1];
-  for (int idx = 0; idx < num_lookups; ++idx) {
-    const int value_offset = args[idx].offset_indices_[blockIdx.x];
-    int feature_num;
-    if (blockIdx.x == int(batch_size) - 1) {
-      feature_num = int(args[idx].nnz_) - value_offset;
-    } else {
-      feature_num = args[idx].offset_indices_[blockIdx.x + 1] - value_offset;
-    }
-    float grad = args[idx].grads_[blockIdx.x * dimension + threadIdx.x];
-    // printf("feature_num is %d , grad is %lld , bid is %d , tid is %d \n",
-    // feature_num, grad, blockIdx.x, threadIdx.x);
-    grad = CombineGrad<combiner>(grad, feature_num);
-    for (int i = 0; i < feature_num; i++) {
-      float grad_i = grad;
-      if (max_norm > 0.0f) {
-        int64_t indices = int(args[idx].sp_values_[value_offset + i]);
-        float emb_element = 0.0f;
-        if (FastBoundsCheck(indices, args[idx].emb_row_size_)) {
-          emb_element =
-              args[idx].emb_variable_[indices * dimension + threadIdx.x];
-        }
-        emb_element =
-            args[idx].emb_variable_[indices * dimension + threadIdx.x];
-        if (threadIdx.x == 0) {
-          l2_sum[0] = 0.0f;
-        }
-        __syncthreads();
-        atomicAdd(l2_sum, emb_element * emb_element);
-        __syncthreads();
-        float l2_norm = sqrtf(l2_sum[0]);
-        if (l2_norm > max_norm) {
-          grad_i *= max_norm / l2_norm;
-        }
-      }
-      args[idx].grads_output_[(value_offset + i) * dimension + threadIdx.x] =
-          grad_i;
-    }
-  }
-}
-
-}  // namespace
-
-template <typename TKey, typename TValue>
-class GroupEmbeddingBackWard {
- public:
-  void initialize(int num_lookups) {
-    nums_ = num_lookups;
-    args_.resize(num_lookups);
-    CK_CUDA_THROW_(cudaMalloc(
-        &d_args_,
-        sizeof(GroupEmbeddingBackWardArgs<TKey, TValue>) * num_lookups));
-  }
-
-  void set(int idx, TValue *grads, TValue *grads_output, int *offset_indices,
-           TKey *sp_values, TValue *emb_variable, int64_t emb_row_size,
-           int nnz) {
-    args_[idx].grads_ = grads;
-    args_[idx].grads_output_ = grads_output;
-    args_[idx].offset_indices_ = offset_indices;
-    args_[idx].sp_values_ = sp_values;
-    args_[idx].emb_variable_ = emb_variable;
-    args_[idx].emb_row_size_ = emb_row_size;
-    args_[idx].nnz_ = nnz;
-  }
-
-  ~GroupEmbeddingBackWard() {
-    if (d_args_) {
-      CK_CUDA_THROW_(cudaFree(d_args_));
-    }
-  }
-
-  template <typename GradFn>
-  void compute(GradFn fn, int batch_size, int dimension, float max_norm,
-               cudaStream_t stream) {
-    CK_CUDA_THROW_(cudaMemcpyAsync(
-        d_args_, args_.data(),
-        args_.size() * sizeof(GroupEmbeddingBackWardArgs<TKey, TValue>),
-        cudaMemcpyHostToDevice, stream));
-    CK_CUDA_THROW_(cudaStreamSynchronize(stream));
-    {
-      const int blocks = int(batch_size);
-      const int threads = int(dimension);
-
-      fn<<<blocks, threads, 0, stream>>>(batch_size, dimension, max_norm, nums_,
-                                         d_args_);
-    }
-
-    CK_CUDA_THROW_(cudaGetLastError());
-  }
-
- protected:
-  int nums_;
-  std::vector<GroupEmbeddingBackWardArgs<TKey, TValue>> args_;
-  GroupEmbeddingBackWardArgs<TKey, TValue> *d_args_;
-};
-
-template <typename TKey, typename TValue>
-class GroupLookupBackWardBaseOp : public OpKernel {
- public:
-  explicit GroupLookupBackWardBaseOp(OpKernelConstruction *c) : OpKernel(c) {
-    OP_REQUIRES_OK(c, c->GetAttr("combiner", &combiner_));
-    OP_REQUIRES_OK(c, c->GetAttr("max_norm", &max_norm_));
-    OP_REQUIRES_OK(c, c->GetAttr("num_lookups", &num_lookups_));
-    OP_REQUIRES_OK(c, c->GetAttr("dimension", &dimension_));
-    lookuper_.initialize(num_lookups_);
-  }
-
- protected:
-  std::string combiner_;
-  float max_norm_;
-  int num_lookups_;
-  int dimension_;
-  GroupEmbeddingBackWard<TKey, TValue> lookuper_;
-};
-
 template <typename TFKey, typename TKey, typename TValue>
-class MultiEmbeddingSparseLookupBackWardOp
+class GroupVariableLookupBackwardOp
     : public GroupLookupBackWardBaseOp<TKey, TValue> {
  public:
-  explicit MultiEmbeddingSparseLookupBackWardOp(OpKernelConstruction *c)
+  explicit GroupVariableLookupBackwardOp(OpKernelConstruction *c)
       : GroupLookupBackWardBaseOp<TKey, TValue>(c) {}
 
   void Compute(OpKernelContext *ctx) override {
@@ -230,22 +50,15 @@ class MultiEmbeddingSparseLookupBackWardOp
       const Tensor sp_values_offset_tensor =
           ctx->input(3 * this->num_lookups_ + i);
 
-      int64 emb_row_size = emb_variables_tensor.shape().dim_size(0);
-      if (batch_size == -1) {
+      if (i == 0) {
         batch_size = sp_values_offset_tensor.shape().dim_size(0);
       }
-
-      int dimension = emb_variables_tensor.shape().dim_size(1);
-      OP_REQUIRES(
-          ctx, dimension == this->dimension_,
-          errors::InvalidArgument(
-              "shape[0] of each tensor in offset_indices are different."));
 
       const int64_t nnz = sp_values_tensor.NumElements();
 
       Tensor *grads_sp_values_tensor;
       TensorShape grads_sp_values_tensor_shape =
-          TensorShape(std::vector<int64>({nnz, dimension}));
+          TensorShape(std::vector<int64>({nnz, this->dimension_}));
       OP_REQUIRES_OK(ctx, ctx->allocate_output(i, grads_sp_values_tensor_shape,
                                                &grads_sp_values_tensor));
       this->lookuper_.set(
@@ -255,42 +68,36 @@ class MultiEmbeddingSparseLookupBackWardOp
           const_cast<TKey *>(reinterpret_cast<const TKey *>(
               sp_values_tensor.flat<TFKey>().data())),
           const_cast<TValue *>(emb_variables_tensor.flat<TValue>().data()),
-          emb_row_size, nnz);
+          nnz);
     }
 
     if (this->combiner_ == "mean") {
-      this->lookuper_.compute(ComputeSparseGradFn<TKey, TValue, Mean>,
-                              batch_size, this->dimension_, this->max_norm_,
-                              stream);
+      this->template compute<false, Mean>(batch_size, stream);
     } else if (this->combiner_ == "sum") {
-      this->lookuper_.compute(ComputeSparseGradFn<TKey, TValue, Sum>,
-                              batch_size, this->dimension_, this->max_norm_,
-                              stream);
+      this->template compute<false, Sum>(batch_size, stream);
     } else {
-      this->lookuper_.compute(ComputeSparseGradFn<TKey, TValue, Sqrtn>,
-                              batch_size, this->dimension_, this->max_norm_,
-                              stream);
+      this->template compute<false, Sqrtn>(batch_size, stream);
     }
   }
 };
 
 #define REGISTER_GPU_KERNELS(key_type_tf, key_type, dtype) \
   REGISTER_KERNEL_BUILDER(                                 \
-      Name("MultiEmbeddingSparseLookUpGrad")               \
+      Name("GroupVariableLookupGrad")                      \
           .Device(DEVICE_GPU)                              \
           .TypeConstraint<key_type_tf>("Tkeys")            \
           .TypeConstraint<dtype>("dtype"),                 \
-      MultiEmbeddingSparseLookupBackWardOp<key_type_tf, key_type, dtype>)
+      GroupVariableLookupBackwardOp<key_type_tf, key_type, dtype>)
 
 REGISTER_GPU_KERNELS(int64, int64_t, float);
 REGISTER_GPU_KERNELS(int32, int32_t, float);
 #undef REGISTER_GPU_KERNELS
 
 template <typename TFKey, typename TKey, typename TValue>
-class MultiKvResourceGatherBackWardOp
+class GroupEmbeddingVariableLookupBackwardOp
     : public GroupLookupBackWardBaseOp<TKey, TValue> {
  public:
-  explicit MultiKvResourceGatherBackWardOp(OpKernelConstruction *c)
+  explicit GroupEmbeddingVariableLookupBackwardOp(OpKernelConstruction *c)
       : GroupLookupBackWardBaseOp<TKey, TValue>(c) {}
 
   void Compute(OpKernelContext *ctx) override {
@@ -306,20 +113,16 @@ class MultiKvResourceGatherBackWardOp
       const Tensor sp_values_tensor = ctx->input(2 * this->num_lookups_ + i);
       const Tensor sp_values_offset_tensor =
           ctx->input(3 * this->num_lookups_ + i);
-      int dimension = ev->ValueLen();
-      if (batch_size == -1) {
+      // int dimension = ev->ValueLen();
+      if (i == 0) {
         batch_size = sp_values_offset_tensor.shape().dim_size(0);
       }
-      OP_REQUIRES(
-          ctx, dimension == this->dimension_,
-          errors::InvalidArgument(
-              "shape[0] of each tensor in offset_indices are different."));
 
       const int64_t nnz = sp_values_tensor.NumElements();
 
       Tensor *grads_sp_values_tensor;
       TensorShape grads_sp_values_tensor_shape =
-          TensorShape(std::vector<int64>({nnz, dimension}));
+          TensorShape(std::vector<int64>({nnz, this->dimension_}));
       OP_REQUIRES_OK(ctx, ctx->allocate_output(i, grads_sp_values_tensor_shape,
                                                &grads_sp_values_tensor));
       this->lookuper_.set(
@@ -329,29 +132,26 @@ class MultiKvResourceGatherBackWardOp
           const_cast<TKey *>(reinterpret_cast<const TKey *>(
               sp_values_tensor.flat<TFKey>().data())),
           const_cast<TValue *>(grads_sp_values_tensor->flat<TValue>().data()),
-          -1, nnz);
+          nnz);
     }
 
     if (this->combiner_ == "mean") {
-      this->lookuper_.compute(ComputeEVGradFn<TKey, TValue, Mean>, batch_size,
-                              this->dimension_, this->max_norm_, stream);
+      this->template compute<true, Mean>(batch_size, stream);
     } else if (this->combiner_ == "sum") {
-      this->lookuper_.compute(ComputeEVGradFn<TKey, TValue, Sum>, batch_size,
-                              this->dimension_, this->max_norm_, stream);
+      this->template compute<true, Sum>(batch_size, stream);
     } else {
-      this->lookuper_.compute(ComputeEVGradFn<TKey, TValue, Sqrtn>, batch_size,
-                              this->dimension_, this->max_norm_, stream);
+      this->template compute<true, Sqrtn>(batch_size, stream);
     }
   }
 };
 
 #define REGISTER_GPU_KERNELS(key_type_tf, key_type, dtype) \
   REGISTER_KERNEL_BUILDER(                                 \
-      Name("MultiKvResourceGatherGrad")                    \
+      Name("GroupEmbeddingVariableLookupGrad")             \
           .Device(DEVICE_GPU)                              \
           .TypeConstraint<key_type_tf>("Tkeys")            \
           .TypeConstraint<dtype>("dtype"),                 \
-      MultiKvResourceGatherBackWardOp<key_type_tf, key_type, dtype>)
+      GroupEmbeddingVariableLookupBackwardOp<key_type_tf, key_type, dtype>)
 
 REGISTER_GPU_KERNELS(int64, int64_t, float);
 REGISTER_GPU_KERNELS(int32, int32_t, float);
@@ -359,4 +159,4 @@ REGISTER_GPU_KERNELS(int32, int32_t, float);
 
 }  // namespace tensorflow
 
-#endif // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA

--- a/tensorflow/core/kernels/group_lookup_backward_base_ops.cu.h
+++ b/tensorflow/core/kernels/group_lookup_backward_base_ops.cu.h
@@ -1,0 +1,351 @@
+/* Copyright 2022 The DeepRec Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+
+#define EIGEN_USE_THREADS
+
+#if GOOGLE_CUDA
+#define EIGEN_USE_GPU
+
+#include <cooperative_groups.h>
+#include <cuda_runtime.h>
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/kernels/fused_embedding/fused_embedding_common.cu.h"
+
+namespace tensorflow {
+
+namespace {
+
+template <typename TKey, typename TValue>
+struct GroupEmbeddingBackWardArgs {
+  TValue *grads_;
+  TKey *sp_values_;
+  TValue *emb_variable_;
+  TValue *grads_output_;
+  int *offset_indices_;
+  int nnz_;
+};
+
+template <typename TKey, typename TValue, Combiner combiner, int Tilesize>
+__global__ void ComputeEVGradFn(
+    const int batch_size, const float max_norm, const int num_lookups,
+    const int dimension, GroupEmbeddingBackWardArgs<TKey, TValue> *args) {
+  float l2_sum;
+
+  const auto &block = cooperative_groups::this_thread_block();
+  const auto &tile = cooperative_groups::tiled_partition<Tilesize>(block);
+  // each block partition corresponding to one sample
+  const int bid =
+      block.group_index().x * tile.meta_group_size() + tile.meta_group_rank();
+  // each thread corresponding to one element in the embedding vector
+  const int tid = tile.thread_rank();
+
+  if (bid < batch_size && tid < dimension) {
+    for (int idx = 0; idx < num_lookups; ++idx) {
+      int value_offset = args[idx].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[idx].nnz_ - value_offset;
+      } else {
+        feature_num = args[idx].offset_indices_[bid + 1] - value_offset;
+      }
+
+      float grad = args[idx].grads_[bid * dimension + tid];
+      grad = CombineGrad<combiner>(grad, feature_num);
+
+      for (int j = 0; j < feature_num; ++j) {
+        float grad_i = grad;
+        int feature_offset = (value_offset + j) * dimension;
+        if (max_norm > 0.0f) {
+          float emb_element = 0.0f;  // TODO: hujunqi get emb_weight
+          if (tid == 0) {
+            l2_sum = 0.0f;
+          }
+          tile.shfl(l2_sum, 0);
+          atomicAdd(&l2_sum, emb_element * emb_element);
+          tile.sync();
+          float l2_norm = sqrtf(l2_sum);
+          if (l2_norm > max_norm) {
+            grad_i *= max_norm / l2_norm;
+          }
+        }
+        args[idx].grads_output_[(value_offset + j) * dimension + tid] = grad_i;
+      }
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner, int Tilesize>
+__global__ void ComputeSparseGradFn(
+    const int batch_size, const float max_norm, const int num_lookups,
+    const int dimension, GroupEmbeddingBackWardArgs<TKey, TValue> *args) {
+  float l2_sum;
+  const auto &block = cooperative_groups::this_thread_block();
+  const auto &tile = cooperative_groups::tiled_partition<Tilesize>(block);
+  // each block partition corresponding to one sample
+  const int bid =
+      block.group_index().x * tile.meta_group_size() + tile.meta_group_rank();
+  // each thread corresponding to one element in the embedding vector
+  const int tid = tile.thread_rank();
+
+  for (int idx = 0; idx < num_lookups; ++idx) {
+    const int value_offset = args[idx].offset_indices_[bid];
+    int feature_num;
+    if (bid == (batch_size - 1)) {
+      feature_num = args[idx].nnz_ - value_offset;
+    } else {
+      feature_num = args[idx].offset_indices_[bid + 1] - value_offset;
+    }
+    float grad = args[idx].grads_[bid * dimension + tid];
+    // printf("feature_num is %d , grad is %lld , bid is %d , tid is %d \n",
+    // feature_num, grad, blockIdx.x, threadIdx.x);
+    grad = CombineGrad<combiner>(grad, feature_num);
+    for (int i = 0; i < feature_num; i++) {
+      float grad_i = grad;
+      if (max_norm > 0.0f) {
+        int64_t indices = int(args[idx].sp_values_[value_offset + i]);
+        float emb_element = args[idx].emb_variable_[indices * dimension + tid];
+        // if (FastBoundsCheck(indices, args[idx].emb_row_size_)) {
+        //   emb_element =
+        //       args[idx].emb_variable_[indices * dimension + tid];
+        // }
+        if (tid == 0) {
+          l2_sum = 0.0f;
+        }
+        tile.shfl(l2_sum, 0);
+        atomicAdd(&l2_sum, emb_element * emb_element);
+        tile.sync();
+        float l2_norm = sqrtf(l2_sum);
+        if (l2_norm > max_norm) {
+          grad_i *= max_norm / l2_norm;
+        }
+      }
+      args[idx].grads_output_[(value_offset + i) * dimension + tid] = grad_i;
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner>
+__global__ void NormalComputeEVGradFn(
+    const int batch_size, const float max_norm, const int num_lookups,
+    const int dimension, GroupEmbeddingBackWardArgs<TKey, TValue> *args) {
+  __shared__ TValue l2_sum[1];
+
+  const auto &block = cooperative_groups::this_thread_block();
+  // each block partition corresponding to one sample
+  const int bid = block.group_index().x;
+  // each thread corresponding to one element in the embedding vector
+  const int tid = block.thread_rank();
+
+  if (bid < batch_size && tid < dimension) {
+    for (int idx = 0; idx < num_lookups; ++idx) {
+      int value_offset = args[idx].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[idx].nnz_ - value_offset;
+      } else {
+        feature_num = args[idx].offset_indices_[bid + 1] - value_offset;
+      }
+
+      float grad = args[idx].grads_[bid * dimension + tid];
+      grad = CombineGrad<combiner>(grad, feature_num);
+
+      for (int j = 0; j < feature_num; ++j) {
+        float grad_i = grad;
+        int feature_offset = (value_offset + j) * dimension;
+        if (max_norm > 0.0f) {
+          float emb_element = 0.0f;  // TODO: hujunqi get emb_weight
+          if (tid == 0) {
+            l2_sum[0] = 0.0f;
+          }
+          __syncthreads();
+          atomicAdd(l2_sum, emb_element * emb_element);
+          __syncthreads();
+          float l2_norm = sqrtf(l2_sum[0]);
+          if (l2_norm > max_norm) {
+            grad_i *= max_norm / l2_norm;
+          }
+        }
+        args[idx].grads_output_[(value_offset + j) * dimension + tid] = grad_i;
+      }
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner>
+__global__ void NormalComputeSparseGradFn(
+    const int batch_size, const float max_norm, const int num_lookups,
+    const int dimension, GroupEmbeddingBackWardArgs<TKey, TValue> *args) {
+  __shared__ TValue l2_sum[1];
+
+  const auto &block = cooperative_groups::this_thread_block();
+  // each block partition corresponding to one sample
+  const int bid = block.group_index().x;
+  // each thread corresponding to one element in the embedding vector
+  const int tid = block.thread_rank();
+
+  for (int idx = 0; idx < num_lookups; ++idx) {
+    const int value_offset = args[idx].offset_indices_[bid];
+    int feature_num;
+    if (bid == (batch_size - 1)) {
+      feature_num = args[idx].nnz_ - value_offset;
+    } else {
+      feature_num = args[idx].offset_indices_[bid + 1] - value_offset;
+    }
+    float grad = args[idx].grads_[bid * dimension + tid];
+    // printf("feature_num is %d , grad is %lld , bid is %d , tid is %d \n",
+    // feature_num, grad, blockIdx.x, threadIdx.x);
+    grad = CombineGrad<combiner>(grad, feature_num);
+    for (int i = 0; i < feature_num; i++) {
+      float grad_i = grad;
+      if (max_norm > 0.0f) {
+        int64_t indices = int(args[idx].sp_values_[value_offset + i]);
+        float emb_element = args[idx].emb_variable_[indices * dimension + tid];
+        if (tid == 0) {
+          l2_sum[0] = 0.0f;
+        }
+        __syncthreads();
+        atomicAdd(l2_sum, emb_element * emb_element);
+        __syncthreads();
+        float l2_norm = sqrtf(l2_sum[0]);
+        if (l2_norm > max_norm) {
+          grad_i *= max_norm / l2_norm;
+        }
+      }
+      args[idx].grads_output_[(value_offset + i) * dimension + tid] = grad_i;
+    }
+  }
+}
+
+}  // namespace
+
+template <typename TKey, typename TValue>
+class GroupEmbeddingLookupBackWard {
+ public:
+  void initialize(int dimension, int num_lookups, float max_norm) {
+    CK_CUDA_THROW_(cudaMalloc(
+        &d_args_,
+        sizeof(GroupEmbeddingBackWardArgs<TKey, TValue>) * num_lookups));
+    args_.resize(num_lookups);
+    max_norm_ = max_norm;
+    nums_ = num_lookups;
+    dimension_ = dimension;
+  }
+
+  void set(int idx, TValue *grads, TValue *grads_output, int *offset_indices,
+           TKey *sp_values, TValue *emb_variable, int nnz) {
+    args_[idx].grads_ = grads;
+    args_[idx].grads_output_ = grads_output;
+    args_[idx].offset_indices_ = offset_indices;
+    args_[idx].sp_values_ = sp_values;
+    args_[idx].emb_variable_ = emb_variable;
+    args_[idx].nnz_ = nnz;
+  }
+
+  ~GroupEmbeddingLookupBackWard() {
+    if (d_args_) {
+      CK_CUDA_THROW_(cudaFree(d_args_));
+    }
+  }
+
+  template <typename GradFn>
+  void Backward(GradFn fn, int batch_size, int tile_size, cudaStream_t stream) {
+    CK_CUDA_THROW_(cudaMemcpyAsync(
+        d_args_, args_.data(),
+        args_.size() * sizeof(GroupEmbeddingBackWardArgs<TKey, TValue>),
+        cudaMemcpyHostToDevice, stream));
+
+    {
+      const int block_size = (batch_size - 1) / 64 * tile_size + 1;
+
+      fn<<<block_size, 64, 0, stream>>>(batch_size, max_norm_, nums_,
+                                        dimension_, d_args_);
+    }
+
+    CK_CUDA_THROW_(cudaGetLastError());
+  }
+
+ protected:
+  std::vector<GroupEmbeddingBackWardArgs<TKey, TValue>> args_;
+  GroupEmbeddingBackWardArgs<TKey, TValue> *d_args_;
+  float max_norm_;
+  int nums_;
+  int dimension_;
+};
+
+template <typename TKey, typename TValue>
+class GroupLookupBackWardBaseOp : public OpKernel {
+ public:
+  explicit GroupLookupBackWardBaseOp(OpKernelConstruction *c) : OpKernel(c) {
+    OP_REQUIRES_OK(c, c->GetAttr("combiner", &combiner_));
+    OP_REQUIRES_OK(c, c->GetAttr("max_norm", &max_norm_));
+    OP_REQUIRES_OK(c, c->GetAttr("num_lookups", &num_lookups_));
+    OP_REQUIRES_OK(c, c->GetAttr("dimension", &dimension_));
+    lookuper_.initialize(dimension_, num_lookups_, max_norm_);
+  }
+
+  template <bool Isev = false, Combiner combiner>
+  inline void compute(const int batch_size, cudaStream_t stream) {
+    if (Isev) {
+      if (dimension_ <= 2) {
+        lookuper_.Backward(ComputeEVGradFn<TKey, TValue, combiner, 2>,
+                           batch_size, 2, stream);
+      } else if (dimension_ <= 4) {
+        lookuper_.Backward(ComputeEVGradFn<TKey, TValue, combiner, 4>,
+                           batch_size, 4, stream);
+      } else if (dimension_ <= 8) {
+        lookuper_.Backward(ComputeEVGradFn<TKey, TValue, combiner, 8>,
+                           batch_size, 8, stream);
+      } else if (dimension_ <= 16) {
+        lookuper_.Backward(ComputeEVGradFn<TKey, TValue, combiner, 16>,
+                           batch_size, 16, stream);
+      } else if (dimension_ <= 32) {
+        lookuper_.Backward(ComputeEVGradFn<TKey, TValue, combiner, 32>,
+                           batch_size, 32, stream);
+      } else {
+        lookuper_.Backward(NormalComputeEVGradFn<TKey, TValue, combiner>,
+                           batch_size, 64, stream);
+      }
+    } else {
+      if (dimension_ <= 2) {
+        lookuper_.Backward(ComputeSparseGradFn<TKey, TValue, combiner, 2>,
+                           batch_size, 2, stream);
+      } else if (dimension_ <= 4) {
+        lookuper_.Backward(ComputeSparseGradFn<TKey, TValue, combiner, 4>,
+                           batch_size, 4, stream);
+      } else if (dimension_ <= 8) {
+        lookuper_.Backward(ComputeSparseGradFn<TKey, TValue, combiner, 8>,
+                           batch_size, 8, stream);
+      } else if (dimension_ <= 16) {
+        lookuper_.Backward(ComputeSparseGradFn<TKey, TValue, combiner, 16>,
+                           batch_size, 16, stream);
+      } else if (dimension_ <= 32) {
+        lookuper_.Backward(ComputeSparseGradFn<TKey, TValue, combiner, 32>,
+                           batch_size, 32, stream);
+      } else {
+        lookuper_.Backward(NormalComputeSparseGradFn<TKey, TValue, combiner>,
+                           batch_size, 64, stream);
+      }
+    }
+  }
+
+ protected:
+  GroupEmbeddingLookupBackWard<TKey, TValue> lookuper_;
+  std::string combiner_;
+  float max_norm_;
+  int num_lookups_;
+  int dimension_;
+};
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA

--- a/tensorflow/core/kernels/group_lookup_forward.cu.cc
+++ b/tensorflow/core/kernels/group_lookup_forward.cu.cc
@@ -12,9 +12,6 @@ limitations under the License.
 
 #include <inttypes.h>
 
-#include <exception>
-#include <string>
-
 #define EIGEN_USE_THREADS
 
 #if GOOGLE_CUDA
@@ -23,275 +20,23 @@ limitations under the License.
 #include <cuda_runtime.h>
 
 #include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"
-#include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/embedding/embedding_var.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/resource_mgr.h"
 #include "tensorflow/core/framework/resource_var.h"
 #include "tensorflow/core/kernels/fused_embedding/fused_embedding_common.cu.h"
+#include "tensorflow/core/kernels/group_lookup_forward_base_ops.cu.h"
 #include "tensorflow/core/kernels/training_op_helpers.h"
 #include "tensorflow/core/lib/core/spin_rw_lock.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/work_sharder.h"
 #include "tensorflow/stream_executor/stream_executor.h"
+
 namespace tensorflow {
 using GPUDevice = Eigen::GpuDevice;
 
 namespace {
-
-template <typename TKey, typename TValue>
-struct GroupEmbeddingForWardArgs {
-  TValue* emb_variable_;
-  TValue* emb_vector_;
-  TKey* sp_values_;
-  int64_t* sp_indices_;
-  int* offset_indices_;
-  int nnz_;
-  int emb_row_size_;
-};
-
-template <typename TKey, typename TValue>
-__global__ void SetToIntMaxSTG128(const int batch_size, const int num_lookups,
-                                  GroupEmbeddingForWardArgs<TKey, TValue>* args) {
-  const int thread_offset = 4 * (blockIdx.x * blockDim.x + threadIdx.x);
-  const int int_max = 0x7fffffff;
-  for (int idx = 0; idx < num_lookups; ++idx) {
-    int* values_offset = args[idx].offset_indices_;
-    if (thread_offset + 4 < batch_size) {
-      int4 four = make_int4(int_max, int_max, int_max, int_max);
-      *((int4 *)(values_offset + thread_offset)) = four;
-    } else if (thread_offset < batch_size) {
-      for (int i = thread_offset; i < batch_size; i++) {
-        values_offset[i] = int_max;
-      }
-    }
-  }
-}
-
-__global__ void CalcPerElementRowOffset(const int64_t nnz, const int64_t* indices,
-                                        int* values_offset) {
-  const int thread_offset = blockIdx.x * blockDim.x + threadIdx.x;
-  if (thread_offset < int(nnz)) {
-    const int64_t element_row = indices[2 * thread_offset];
-    atomicMin(values_offset + int(element_row), thread_offset);
-  }
-}
-
-template <typename TKey, typename TValue>
-__global__ void FillEmptyRow(const int64_t batch_size, const int num_lookups,
-                             GroupEmbeddingForWardArgs<TKey, TValue>* args) {
-  const int thread_offset = blockIdx.x * blockDim.x + threadIdx.x;
-  const int int_max = 0x7fffffff;
-  if (thread_offset < int(batch_size - 1)) {
-    for (int i = 0; i < num_lookups; ++i) {
-      volatile int* values_offset = args[i].offset_indices_;
-      while (values_offset[thread_offset + 1] == int_max) {
-      }
-      const int compare = values_offset[thread_offset + 1];
-      atomicMin((int *)values_offset + int(thread_offset), compare);
-    }
-  }
-}
-
-template <typename TKey, typename TValue, Combiner combiner>
-__global__ void EmbeddingVarComputeFn(
-    const int batch_size, const int dimension, const float max_norm,
-    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
-  __shared__ TValue l2_sum[1];
-
-  int bid = blockIdx.x;
-  int tid = threadIdx.x;
-
-  if (bid < batch_size && tid < dimension) {
-    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
-      int value_offset = args[ev_id].offset_indices_[bid];
-      int feature_num;
-      if (bid == int(batch_size) - 1) {
-        feature_num = int(args[ev_id].nnz_) - value_offset;
-      } else {
-        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
-      }
-      TValue out = 0.0;
-
-// #pragma unroll
-      for (int j = 0; j < feature_num; ++j) {
-        int64_t feature_offset = (value_offset + j) * dimension;
-        TValue sum = args[ev_id].emb_variable_[feature_offset + tid];
-        if (max_norm >= 0.0) {
-          if (tid == 0) {
-            l2_sum[0] = 0.0;
-          }
-          __syncthreads();
-          atomicAdd(l2_sum, sum * sum);
-          __syncthreads();
-          TValue l2_norm = sqrtf(l2_sum[0]);
-          if (l2_norm > max_norm) {
-            sum *= max_norm / l2_norm;
-          }
-        }
-        out += sum;
-      }
-
-      out = Combine<combiner>(out, feature_num);
-      args[ev_id].emb_vector_[bid * dimension + tid] = out;
-    }
-  }
-}
-
-template <typename TKey, typename TValue, Combiner combiner>
-__global__ void VariableComputeFn(
-    const int batch_size, const int emb_vec_size, const float max_norm,
-    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
-  __shared__ TValue l2_sum[1];
-  int bid = blockIdx.x;
-  int tid = threadIdx.x;
-
-  if (bid < batch_size && tid < emb_vec_size) {
-    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
-      int value_offset = args[ev_id].offset_indices_[bid];
-      int feature_num;
-      if (bid == int(batch_size) - 1) {
-        feature_num = int(args[ev_id].nnz_) - value_offset;
-      } else {
-        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
-      }
-
-      TValue out = 0.0f;
-
-      const TValue* emb_variable = args[ev_id].emb_variable_;
-      const int64_t emb_dim_limit = args[ev_id].emb_row_size_;
-// #pragma unroll
-      for (int i = 0; i < feature_num; i++) {
-        int64_t indices = int(args[ev_id].sp_values_[value_offset + i]);
-        TValue emb_element = 0.0;
-        if (FastBoundsCheck(indices, emb_dim_limit)) {
-          emb_element = emb_variable[indices * emb_vec_size + tid];
-        }
-        if (max_norm >= 0.0f) {
-          // calc l2 norm of this emb row(per block) and compare with
-          // max_norm.
-          // if greater than max_norm, then clip every element with factor
-          // max_norm / l2norm
-          if (tid == 0) {
-            l2_sum[0] = 0.0f;
-          }
-          __syncthreads();
-          atomicAdd(l2_sum, emb_element * emb_element);
-          __syncthreads();
-          TValue l2_norm = sqrtf(l2_sum[0]);
-          if (l2_norm > max_norm) {
-            emb_element *= max_norm / l2_norm;
-          }
-        }
-        out += emb_element;
-      }
-      out = Combine<combiner>(out, feature_num);
-      args[ev_id].emb_vector_[bid * emb_vec_size + tid] = out;
-    }
-  }
-}
-
-}  // namespace
-
-template <typename TKey, typename TValue>
-class GroupEmbeddingLookupForWard {
- public:
-  void initialize(const int num_lookups, const int dimension,
-                  const float max_norm) {
-    max_norm_ = max_norm;
-    dimension_ = dimension;
-    ev_nums_ = num_lookups;
-    args_size_ = sizeof(GroupEmbeddingForWardArgs<TKey, TValue>);
-    CK_CUDA_THROW_(cudaMalloc(&d_args_, args_size_ * num_lookups));
-    h_args_.resize(ev_nums_);
-  }
-
-  ~GroupEmbeddingLookupForWard() {
-    if (d_args_) {
-      CK_CUDA_THROW_(cudaFree(d_args_));
-    }
-  }
-
-  void set(int idx, TValue* emb_variable, TValue* emb_vector,
-           int* offset_indices, int nnz, int64_t* sp_indices = nullptr,
-           TKey* sp_values = nullptr, int emb_row_size = -1) {
-    h_args_[idx].emb_variable_ = emb_variable;
-    h_args_[idx].emb_vector_ = emb_vector;
-    h_args_[idx].offset_indices_ = offset_indices;
-    h_args_[idx].sp_indices_ = sp_indices;
-    h_args_[idx].nnz_ = nnz;
-    h_args_[idx].sp_values_ = sp_values;
-    h_args_[idx].emb_row_size_ = emb_row_size;
-  }
-  template <typename ForwardFn>
-  void compute(ForwardFn compute_fn, const int batch_size,
-               cudaStream_t stream) {
-    CK_CUDA_THROW_(cudaMemcpyAsync(d_args_, h_args_.data(),
-                                   ev_nums_ * args_size_,
-                                   cudaMemcpyHostToDevice, stream));
-
-    {
-      constexpr int threads = 1024;
-      int blocks = batch_size / threads;
-      blocks = batch_size % threads == 0 ? blocks : blocks + 1;
-      SetToIntMaxSTG128<<<blocks, threads, 0, stream>>>(
-          int(batch_size), ev_nums_, d_args_);
-
-      for (int i = 0; i < ev_nums_; ++i) {
-        int &nnz = h_args_[i].nnz_;
-        int blocks = nnz % threads == 0 ? (nnz / threads) : (nnz / threads + 1);
-        CalcPerElementRowOffset<<<blocks, threads, 0, stream>>>(
-            nnz, h_args_[i].sp_indices_, h_args_[i].offset_indices_);
-      }
-
-      blocks = batch_size % threads == 0 ? (batch_size / threads)
-                                         : (batch_size / threads + 1);
-
-      FillEmptyRow<<<blocks, threads, 0, stream>>>(batch_size, ev_nums_, d_args_);
-    }
-
-    CK_CUDA_THROW_(cudaStreamSynchronize(stream));
-
-    {
-      // TODO: double check why mapped 2D grid slower
-      const int block_size = int(batch_size);
-      const int threads = int(dimension_);
-      compute_fn<<<block_size, threads, 0, stream>>>(
-          batch_size, dimension_, max_norm_, ev_nums_, d_args_);
-    }
-
-    CK_CUDA_THROW_(cudaGetLastError());
-  }
-
- protected:
-  std::vector<GroupEmbeddingForWardArgs<TKey, TValue>> h_args_;
-  GroupEmbeddingForWardArgs<TKey, TValue>* d_args_{nullptr};
-  float max_norm_{0.0f};
-  int ev_nums_{0};
-  int dimension_{0};
-  size_t args_size_{0};
-};
-
-template <typename TKey, typename TValue>
-class GroupEmbeddingLookupForwardBaseOp : public OpKernel {
- public:
-  explicit GroupEmbeddingLookupForwardBaseOp(OpKernelConstruction *c)
-      : OpKernel(c) {
-    OP_REQUIRES_OK(c, c->GetAttr("combiner", &combiner_));
-    OP_REQUIRES_OK(c, c->GetAttr("num_lookups", &num_lookups_));
-    OP_REQUIRES_OK(c, c->GetAttr("dimension", &dimension_));
-    OP_REQUIRES_OK(c, c->GetAttr("max_norm", &max_norm_));
-    lookuper_.initialize(num_lookups_, dimension_, max_norm_);
-  }
-
- protected:
-  GroupEmbeddingLookupForWard<TKey, TValue> lookuper_;
-  std::string combiner_;
-  float max_norm_;
-  int num_lookups_;
-  int dimension_;
-};
 
 template <typename TFKey, typename TKey, typename TValue>
 class GroupEmbeddingVarLookupOp
@@ -301,16 +46,18 @@ class GroupEmbeddingVarLookupOp
       : GroupEmbeddingLookupForwardBaseOp<TKey, TValue>(c) {
     OP_REQUIRES_OK(c, c->GetAttr("is_use_default_value_tensor",
                                  &is_use_default_value_tensor_));
+
     if (is_use_default_value_tensor_) {
-      get_default_v_fn_ = [](TValue *default_v, TFKey id, int64 index,
+      get_default_v_fn_ = [](TValue* default_v, TFKey id, int64 index,
                              int64 total_dim,
                              int64 len) { return default_v + len * index; };
     } else {
-      get_default_v_fn_ = [](TValue *default_v, TFKey id, int64 index,
+      get_default_v_fn_ = [](TValue* default_v, TFKey id, int64 index,
                              int64 total_dim, int64 len) {
         return default_v + len * (id % total_dim);
       };
     }
+
     tensor_list_.reserve(this->num_lookups_);
   }
 
@@ -319,8 +66,11 @@ class GroupEmbeddingVarLookupOp
   void Compute(OpKernelContext* ctx) override {
     EmbeddingVar<TFKey, TValue>* ev = nullptr;
     const auto& device = ctx->eigen_device<GPUDevice>();
-    int64_t batch_size = -1;
-    TValue *default_v = nullptr;
+    TValue* default_v = nullptr;
+
+    const Tensor& dense_shape_tensor = ctx->input(this->num_lookups_ * 4);
+    auto dense_shape = dense_shape_tensor.flat<int>().data();
+    int batch_size = dense_shape[0];
 
     for (size_t i = 0; i < this->num_lookups_; ++i) {
       const Tensor& sp_values_tensor = ctx->input(this->num_lookups_ + i);
@@ -331,17 +81,10 @@ class GroupEmbeddingVarLookupOp
       auto sp_indices = sp_indices_tensor.flat<int64>().data();
       int nnz = sp_indices_tensor.shape().dim_size(0);
 
-      if (i == 0) {
-        const Tensor& dense_shape_tensor =
-            ctx->input(this->num_lookups_ * 3 + i);
-        auto dense_shape = dense_shape_tensor.flat<int64>().data();
-        batch_size = dense_shape[0];
-      }
-
       OP_REQUIRES_OK(ctx, LookupResource(ctx, HandleFromInput(ctx, i), &ev));
       core::ScopedUnref unref_me(ev);
       if (is_use_default_value_tensor_) {
-        default_v = (TValue *)ctx->input(4 * this->num_lookups_).data();
+        default_v = (TValue*)ctx->input(5 * this->num_lookups_).data();
       } else {
         default_v = ev->GetDefaultValuePtr();
       }
@@ -356,7 +99,7 @@ class GroupEmbeddingVarLookupOp
 
       if (ev->IsSingleHbm()) {
         if (is_use_default_value_tensor_) {
-          Tensor default_values(ctx->input(4 * this->num_lookups_));
+          Tensor default_values(ctx->input(5 * this->num_lookups_));
           auto default_value_num = default_values.NumElements() / dimension;
           auto default_values_matrix =
               default_values.shaped<TValue, 2>({default_value_num, dimension});
@@ -373,7 +116,7 @@ class GroupEmbeddingVarLookupOp
             out_tensor.shaped<TValue, 2>({N, out_tensor.NumElements() / N});
         const int64 slice_elems = out_flat.dimension(1);
         const size_t slice_bytes = slice_elems * sizeof(TValue);
-        TValue** memcpy_address = new TValue* [N];
+        TValue** memcpy_address = new TValue*[N];
         TFKey* indices_host = new TFKey[N];
 
         auto worker_threads = ctx->device()->tensorflow_cpu_worker_threads();
@@ -394,7 +137,7 @@ class GroupEmbeddingVarLookupOp
         auto stream = ctx->op_device_context()->stream();
         auto event_mgr = ctx->device()->tensorflow_gpu_device_info()->event_mgr;
 
-        se::DeviceMemoryBase gpu_src(const_cast<TFKey *>(key_base),
+        se::DeviceMemoryBase gpu_src(const_cast<TFKey*>(key_base),
                                      N * sizeof(TFKey));
         stream->ThenMemcpy(indices_host, gpu_src, N * sizeof(TFKey));
         SyncWithEventMgr(stream, event_mgr);
@@ -464,14 +207,14 @@ class GroupEmbeddingVarLookupOp
 
         if (ev->IsMultiLevel()) {
           ev->storage_manager()->Schedule([ev, indices_host, N]() {
-            embedding::BatchCache<TFKey> *cache = ev->Cache();
+            embedding::BatchCache<TFKey>* cache = ev->Cache();
             cache->add_to_rank(indices_host, N);
             delete[] indices_host;
           });
         }
       }
 
-      Tensor *op_output_tensor = nullptr;
+      Tensor* op_output_tensor = nullptr;
       OP_REQUIRES_OK(ctx, ctx->allocate_output(i, {batch_size, dimension},
                                                &op_output_tensor));
       auto op_output = op_output_tensor->flat<TValue>().data();
@@ -485,30 +228,40 @@ class GroupEmbeddingVarLookupOp
                                                values_offset_tensor_shape,
                                                &values_offset_tensor));
       auto values_offset = values_offset_tensor->flat<int>().data();
-      this->lookuper_.set(
-          i, out_base, op_output, values_offset, nnz,
-          const_cast<int64_t *>(reinterpret_cast<const int64_t *>(sp_indices)));
+
+      launch_cal_per_element_row_offset(
+          batch_size, nnz, reinterpret_cast<const int64_t*>(sp_indices),
+          values_offset, device.stream());
+
+      TValue* sp_weights = nullptr;
+      if (!this->ignore_weights_) {
+        const Tensor& sp_weights_tensor =
+            ctx->input(this->num_lookups_ * 3 + i);
+        sp_weights =
+            const_cast<TValue*>(sp_weights_tensor.flat<TValue>().data());
+      }
+
+      this->lookuper_.set(i, out_base, op_output, values_offset, nnz,
+                          sp_weights);
+
       tensor_list_.emplace_back(out_tensor);
     }
 
-    if (this->combiner_ == "mean") {
-      this->lookuper_.compute(EmbeddingVarComputeFn<TKey, TValue, Mean>,
-                              batch_size, device.stream());
-    } else if (this->combiner_ == "sum") {
-      this->lookuper_.compute(EmbeddingVarComputeFn<TKey, TValue, Sum>,
-                              batch_size, device.stream());
+    if (this->combiner_ == "sum") {
+      this->template compute<true, Sum>(batch_size, device.stream());
+    } else if (this->combiner_ == "mean") {
+      this->template compute<true, Mean>(batch_size, device.stream());
     } else {
-      this->lookuper_.compute(EmbeddingVarComputeFn<TKey, TValue, Sqrtn>,
-                              batch_size, device.stream());
+      this->template compute<true, Sqrtn>(batch_size, device.stream());
     }
+
     tensor_list_.clear();
   }
 
  private:
   std::vector<Tensor> tensor_list_;
   std::map<uint64, int64> hash_map_;
-  std::function<TValue *(TValue *, TFKey, int64, int64, int64)>
-      get_default_v_fn_;
+  std::function<TValue*(TValue*, TFKey, int64, int64, int64)> get_default_v_fn_;
   mutable easy_spinrwlock_t mu_ = EASY_SPINRWLOCK_INITIALIZER;
   bool* occupy_flag_{nullptr};
   mutex m_init_occupy_flag_;
@@ -533,12 +286,13 @@ class GroupVariableLookupOp
     : public GroupEmbeddingLookupForwardBaseOp<TKey, TValue> {
  public:
   explicit GroupVariableLookupOp(OpKernelConstruction* c)
-      : GroupEmbeddingLookupForwardBaseOp<TKey, TValue>(c) {
-  }
+      : GroupEmbeddingLookupForwardBaseOp<TKey, TValue>(c) {}
 
   void Compute(OpKernelContext* ctx) override {
     const cudaStream_t stream = ctx->eigen_device<GPUDevice>().stream();
-    int batch_size = -1;
+    const Tensor& dense_shape_tensor = ctx->input(this->num_lookups_ * 4);
+    auto dense_shape = dense_shape_tensor.flat<int>().data();
+    int batch_size = dense_shape[0];
 
     for (int i = 0; i < this->num_lookups_; ++i) {
       const Tensor& emb_variable_tensor = ctx->input(i);
@@ -547,14 +301,8 @@ class GroupVariableLookupOp
       int64 emb_vec_size = emb_variable_tensor.shape().dim_size(1);
 
       const Tensor& sp_indices_tensor = ctx->input(this->num_lookups_ * 2 + i);
+      auto sp_indices = sp_indices_tensor.flat<int64>().data();
       int nnz = sp_indices_tensor.shape().dim_size(0);
-
-      if (i == 0) {
-        const Tensor& dense_shape_tensor =
-            ctx->input(this->num_lookups_ * 3 + i);
-        auto dense_shape = dense_shape_tensor.flat<int64>().data();
-        batch_size = dense_shape[0];
-      }
 
       TensorShape emb_vectors_tensor_shape = TensorShape(std::vector<int64>(
           {static_cast<long long>(batch_size), emb_vec_size}));
@@ -572,31 +320,34 @@ class GroupVariableLookupOp
                                                values_offset_tensor_shape,
                                                &values_offset_tensor));
       auto values_offset = values_offset_tensor->flat<int>().data();
+      launch_cal_per_element_row_offset(
+          batch_size, nnz, reinterpret_cast<const int64_t*>(sp_indices),
+          values_offset, stream);
 
-      this->lookuper_.set(
-          i,
-          const_cast<TValue *>(reinterpret_cast<const TValue *>(
-              emb_variable_tensor.flat<TValue>().data())),
-          emb_vectors, values_offset, nnz,
-          const_cast<int64_t *>(reinterpret_cast<const int64_t *>(
-              sp_indices_tensor.flat<int64>().data())),
-          const_cast<TKey *>(reinterpret_cast<const TKey *>(
-              sp_values_tensor.flat<TFKey>().data())),
-          emb_row_size);
+      TValue* sp_weights = nullptr;
+      if (!this->ignore_weights_) {
+        const Tensor& sp_weights_tensor =
+            ctx->input(this->num_lookups_ * 3 + i);
+        sp_weights =
+            const_cast<TValue*>(sp_weights_tensor.flat<TValue>().data());
+      }
+
+      this->lookuper_.set(i,
+                          const_cast<TValue*>(reinterpret_cast<const TValue*>(
+                              emb_variable_tensor.flat<TValue>().data())),
+                          emb_vectors, values_offset, nnz, sp_weights,
+                          const_cast<TKey*>(reinterpret_cast<const TKey*>(
+                              sp_values_tensor.flat<TFKey>().data())),
+                          emb_row_size);
     }
-
-    if (this->combiner_ == "mean") {
-      this->lookuper_.compute(VariableComputeFn<TKey, TValue, Mean>, batch_size,
-                              stream);
-    } else if (this->combiner_ == "sum") {
-      this->lookuper_.compute(VariableComputeFn<TKey, TValue, Sum>, batch_size,
-                              stream);
+    if (this->combiner_ == "sum") {
+      this->template compute<false, Sum>(batch_size, stream);
+    } else if (this->combiner_ == "mean") {
+      this->template compute<false, Mean>(batch_size, stream);
     } else {
-      this->lookuper_.compute(VariableComputeFn<TKey, TValue, Sqrtn>,
-                              batch_size, stream);
+      this->template compute<false, Sqrtn>(batch_size, stream);
     }
   }
-
 };
 
 #define REGISTER_GPU_KERNELS(key_type_tf, key_type, dtype_tf, dtype) \
@@ -610,7 +361,7 @@ class GroupVariableLookupOp
 REGISTER_GPU_KERNELS(int64, int64_t, float, float);
 REGISTER_GPU_KERNELS(int32, int32_t, float, float);
 #undef REGISTER_GPU_KERNELS
-
+}  // namespace
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA

--- a/tensorflow/core/kernels/group_lookup_forward_base_ops.cu.h
+++ b/tensorflow/core/kernels/group_lookup_forward_base_ops.cu.h
@@ -1,0 +1,688 @@
+/* Copyright 2022 The DeepRec Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+
+#if GOOGLE_CUDA
+
+#include <cooperative_groups.h>
+#include <cuda_runtime.h>
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/kernels/fused_embedding/fused_embedding_common.cu.h"
+#include "tensorflow/core/kernels/training_op_helpers.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
+#include "tensorflow/stream_executor/stream_executor.h"
+
+namespace tensorflow {
+
+namespace {
+
+template <typename TKey, typename TValue>
+struct GroupEmbeddingForWardArgs {
+  TValue* emb_variable_;
+  TValue* emb_vector_;
+  TValue* sp_weights_;
+  TKey* sp_values_;
+  int* offset_indices_;
+  int nnz_;
+  int emb_row_size_;
+};
+
+__global__ void SetToIntMaxSTG128(const int batch_size, int* values_offset) {
+  const int thread_offset = 4 * (blockIdx.x * blockDim.x + threadIdx.x);
+  const int int_max = 0x7fffffff;
+  if (thread_offset + 4 < batch_size) {
+    int4 four = make_int4(int_max, int_max, int_max, int_max);
+    *((int4*)(values_offset + thread_offset)) = four;
+  } else if (thread_offset < batch_size) {
+    for (int i = thread_offset; i < batch_size; i++) {
+      values_offset[i] = int_max;
+    }
+  }
+}
+
+__global__ void CalcPerElementRowOffset(const int batch_size, const int64_t nnz,
+                                        const int64_t* indices,
+                                        volatile int* values_offset) {
+  const int thread_offset = blockIdx.x * blockDim.x + threadIdx.x;
+  const int int_max = 0x7fffffff;
+  if (thread_offset < int(nnz)) {
+    const int64_t element_row = indices[thread_offset];
+    atomicMin((int*)values_offset + int(element_row), thread_offset);
+    __syncthreads();
+    if (thread_offset < int(batch_size - 1)) {
+      while (values_offset[thread_offset + 1] == int_max) {
+      }
+      const int compare = values_offset[thread_offset + 1];
+      atomicMin((int*)values_offset + thread_offset, compare);
+    }
+  }
+}
+
+inline void launch_cal_per_element_row_offset(const int batch_size, int nnz,
+                                              const int64_t* sp_indices,
+                                              int* offset_indices,
+                                              cudaStream_t stream) {
+  static int threads = 1024;
+  int blocks = (batch_size - 1) / threads + 1;
+
+  SetToIntMaxSTG128<<<blocks, threads, 0, stream>>>(batch_size, offset_indices);
+
+  blocks = (nnz - 1) / threads + 1;
+  CalcPerElementRowOffset<<<blocks, threads, 0, stream>>>(
+      batch_size, nnz, sp_indices, offset_indices);
+}
+
+template <typename TKey, typename TValue, Combiner combiner, int Tilesize>
+__global__ void WeightedEmbeddingVarComputeFn(
+    const int batch_size, const int dimension, const float max_norm,
+    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
+  TValue l2_sum;
+
+  const auto& block = cooperative_groups::this_thread_block();
+  const auto& tile = cooperative_groups::tiled_partition<Tilesize>(block);
+  // each block partition corresponding to one sample
+  const int bid =
+      block.group_index().x * tile.meta_group_size() + tile.meta_group_rank();
+  // each thread corresponding to one element in the embedding vector
+  const int tid = tile.thread_rank();
+
+  if (bid < batch_size && tid < dimension) {
+    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
+      int value_offset = args[ev_id].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[ev_id].nnz_ - value_offset;
+      } else {
+        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
+      }
+
+      TValue out = 0.0;
+
+      // #pragma unroll
+      for (int j = 0; j < feature_num; ++j) {
+        int64_t feature_offset = (value_offset + j) * dimension;
+        TValue sum = args[ev_id].emb_variable_[feature_offset + tid];
+        TValue sp_weights = args[ev_id].sp_weights_[bid * dimension + tid];
+        if (max_norm >= 0.0) {
+          if (tid == 0) {
+            l2_sum = 0.0;
+          }
+          tile.shfl(l2_sum, 0);
+          atomicAdd(&l2_sum, sum * sum);
+          tile.sync();
+          TValue l2_norm = sqrtf(l2_sum);
+          if (l2_norm > max_norm) {
+            sum *= max_norm / l2_norm;
+          }
+        }
+        out += sum * sp_weights;
+      }
+
+      out = Combine<combiner>(out, feature_num);
+      args[ev_id].emb_vector_[bid * dimension + tid] = out;
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner, int Tilesize>
+__global__ void WeightedVariableComputeFn(
+    const int batch_size, const int emb_vec_size, const float max_norm,
+    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
+  TValue l2_sum;
+  const auto& block = cooperative_groups::this_thread_block();
+  const auto& tile = cooperative_groups::tiled_partition<Tilesize>(block);
+  // each block partition corresponding to one sample
+  const int bid =
+      block.group_index().x * tile.meta_group_size() + tile.meta_group_rank();
+  // each thread corresponding to one element in the embedding vector
+  const int tid = tile.thread_rank();
+
+  if (bid < batch_size && tid < emb_vec_size) {
+    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
+      int value_offset = args[ev_id].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[ev_id].nnz_ - value_offset;
+      } else {
+        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
+      }
+
+      TValue out = 0.0f;
+
+      const TValue* emb_variable = args[ev_id].emb_variable_;
+      const int64_t emb_dim_limit = args[ev_id].emb_row_size_;
+      // #pragma unroll
+      for (int i = 0; i < feature_num; i++) {
+        int indices = int(args[ev_id].sp_values_[value_offset + i]);
+        TValue sp_weights = args[ev_id].sp_weights_[bid * emb_vec_size + tid];
+        TValue emb_element = emb_variable[indices * emb_vec_size + tid];
+        if (max_norm >= 0.0f) {
+          // calc l2 norm of this emb row(per block) and compare with
+          // max_norm.
+          // if greater than max_norm, then clip every element with factor
+          // max_norm / l2norm
+          if (tid == 0) {
+            l2_sum = 0.0f;
+          }
+          tile.shfl(l2_sum, 0);
+          atomicAdd(&l2_sum, emb_element * emb_element);
+          tile.sync();
+          TValue l2_norm = sqrtf(l2_sum);
+          if (l2_norm > max_norm) {
+            emb_element *= max_norm / l2_norm;
+          }
+        }
+        out += emb_element * sp_weights;
+      }
+      out = Combine<combiner>(out, feature_num);
+      args[ev_id].emb_vector_[bid * emb_vec_size + tid] = out;
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner, int Tilesize>
+__global__ void EmbeddingVarComputeFn(
+    const int batch_size, const int dimension, const float max_norm,
+    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
+  TValue l2_sum;
+
+  const auto& block = cooperative_groups::this_thread_block();
+  const auto& tile = cooperative_groups::tiled_partition<Tilesize>(block);
+  // each block partition corresponding to one sample
+  const int bid =
+      block.group_index().x * tile.meta_group_size() + tile.meta_group_rank();
+  // each thread corresponding to one element in the embedding vector
+  const int tid = tile.thread_rank();
+
+  if (bid < batch_size && tid < dimension) {
+    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
+      int value_offset = args[ev_id].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[ev_id].nnz_ - value_offset;
+      } else {
+        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
+      }
+      TValue out = 0.0;
+
+      // #pragma unroll
+      for (int j = 0; j < feature_num; ++j) {
+        int64_t feature_offset = (value_offset + j) * dimension;
+        TValue sum = args[ev_id].emb_variable_[feature_offset + tid];
+        if (max_norm >= 0.0) {
+          if (tid == 0) {
+            l2_sum = 0.0;
+          }
+          tile.shfl(l2_sum, 0);
+          atomicAdd(&l2_sum, sum * sum);
+          tile.sync();
+          TValue l2_norm = sqrtf(l2_sum);
+          if (l2_norm > max_norm) {
+            sum *= max_norm / l2_norm;
+          }
+        }
+        out += sum;
+      }
+
+      out = Combine<combiner>(out, feature_num);
+      args[ev_id].emb_vector_[bid * dimension + tid] = out;
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner, int Tilesize>
+__global__ void VariableComputeFn(
+    const int batch_size, const int emb_vec_size, const float max_norm,
+    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
+  TValue l2_sum;
+  const auto& block = cooperative_groups::this_thread_block();
+  const auto& tile = cooperative_groups::tiled_partition<Tilesize>(block);
+  // each block partition corresponding to one sample
+  const int bid =
+      block.group_index().x * tile.meta_group_size() + tile.meta_group_rank();
+  // each thread corresponding to one element in the embedding vector
+  const int tid = tile.thread_rank();
+
+  if (bid < batch_size && tid < emb_vec_size) {
+    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
+      int value_offset = args[ev_id].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[ev_id].nnz_ - value_offset;
+      } else {
+        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
+      }
+      TValue out = 0.0f;
+
+      const TValue* emb_variable = args[ev_id].emb_variable_;
+      const int64_t emb_dim_limit = args[ev_id].emb_row_size_;
+      // #pragma unroll
+      for (int i = 0; i < feature_num; i++) {
+        int indices = int(args[ev_id].sp_values_[value_offset + i]);
+        TValue emb_element = emb_variable[indices * emb_vec_size + tid];
+        // printf("indices is %d emb_element is %f\n", indices, emb_element);
+        if (max_norm >= 0.0f) {
+          // calc l2 norm of this emb row(per block) and compare with
+          // max_norm.
+          // if greater than max_norm, then clip every element with factor
+          // max_norm / l2norm
+          if (tid == 0) {
+            l2_sum = 0.0f;
+          }
+          tile.shfl(l2_sum, 0);
+          atomicAdd(&l2_sum, emb_element * emb_element);
+          tile.sync();
+          TValue l2_norm = sqrtf(l2_sum);
+          if (l2_norm > max_norm) {
+            emb_element *= max_norm / l2_norm;
+          }
+        }
+        out += emb_element;
+      }
+      out = Combine<combiner>(out, feature_num);
+      // printf("feature_num is %d value_offset is %d out is %f\n", feature_num,
+      // value_offset, out);
+      args[ev_id].emb_vector_[bid * emb_vec_size + tid] = out;
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner>
+__global__ void NormalEmbeddingVarComputeFn(
+    const int batch_size, const int dimension, const float max_norm,
+    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
+  __shared__ TValue l2_sum[1];
+
+  const auto& block = cooperative_groups::this_thread_block();
+  // each block partition corresponding to one sample
+  const int bid = block.group_index().x;
+  // each thread corresponding to one element in the embedding vector
+  const int tid = block.thread_rank();
+
+  if (bid < batch_size && tid < dimension) {
+    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
+      int value_offset = args[ev_id].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[ev_id].nnz_ - value_offset;
+      } else {
+        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
+      }
+      TValue out = 0.0;
+
+      // #pragma unroll
+      for (int j = 0; j < feature_num; ++j) {
+        int64_t feature_offset = (value_offset + j) * dimension;
+        TValue sum = args[ev_id].emb_variable_[feature_offset + tid];
+        if (max_norm >= 0.0) {
+          if (tid == 0) {
+            l2_sum[0] = 0.0;
+          }
+          block.sync();
+          atomicAdd(l2_sum, sum * sum);
+          block.sync();
+          TValue l2_norm = sqrtf(l2_sum[0]);
+          if (l2_norm > max_norm) {
+            sum *= max_norm / l2_norm;
+          }
+        }
+        out += sum;
+      }
+
+      out = Combine<combiner>(out, feature_num);
+      args[ev_id].emb_vector_[bid * dimension + tid] = out;
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner>
+__global__ void NormalVariableComputeFn(
+    const int batch_size, const int emb_vec_size, const float max_norm,
+    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
+  __shared__ TValue l2_sum[1];
+  const auto& block = cooperative_groups::this_thread_block();
+  // each block partition corresponding to one sample
+  const int bid = block.group_index().x;
+  // each thread corresponding to one element in the embedding vector
+  const int tid = block.thread_rank();
+
+  if (bid < batch_size && tid < emb_vec_size) {
+    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
+      int value_offset = args[ev_id].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[ev_id].nnz_ - value_offset;
+      } else {
+        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
+      }
+      TValue out = 0.0f;
+
+      const TValue* emb_variable = args[ev_id].emb_variable_;
+      const int64_t emb_dim_limit = args[ev_id].emb_row_size_;
+      // #pragma unroll
+      for (int i = 0; i < feature_num; i++) {
+        int indices = int(args[ev_id].sp_values_[value_offset + i]);
+        TValue emb_element = emb_variable[indices * emb_vec_size + tid];
+        // printf("indices is %d emb_element is %f\n", indices, emb_element);
+        if (max_norm >= 0.0f) {
+          // calc l2 norm of this emb row(per block) and compare with
+          // max_norm.
+          // if greater than max_norm, then clip every element with factor
+          // max_norm / l2norm
+          if (tid == 0) {
+            l2_sum[0] = 0.0f;
+          }
+          block.sync();
+          atomicAdd(l2_sum, emb_element * emb_element);
+          block.sync();
+          TValue l2_norm = sqrtf(l2_sum[0]);
+          if (l2_norm > max_norm) {
+            emb_element *= max_norm / l2_norm;
+          }
+        }
+        out += emb_element;
+      }
+      out = Combine<combiner>(out, feature_num);
+      // printf("feature_num is %d value_offset is %d out is %f\n", feature_num,
+      // value_offset, out);
+      args[ev_id].emb_vector_[bid * emb_vec_size + tid] = out;
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner>
+__global__ void NormalWeightedEmbeddingVarComputeFn(
+    const int batch_size, const int dimension, const float max_norm,
+    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
+  __shared__ TValue l2_sum[1];
+
+  const auto& block = cooperative_groups::this_thread_block();
+  // each block partition corresponding to one sample
+  const int bid = block.group_index().x;
+  // each thread corresponding to one element in the embedding vector
+  const int tid = block.thread_rank();
+
+  if (bid < batch_size && tid < dimension) {
+    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
+      int value_offset = args[ev_id].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[ev_id].nnz_ - value_offset;
+      } else {
+        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
+      }
+      TValue out = 0.0;
+
+      // #pragma unroll
+      for (int j = 0; j < feature_num; ++j) {
+        int64_t feature_offset = (value_offset + j) * dimension;
+        TValue sum = args[ev_id].emb_variable_[feature_offset + tid];
+        TValue sp_weights =
+            args[ev_id].sp_weights_[feature_offset + tid];
+        if (max_norm >= 0.0) {
+          if (tid == 0) {
+            l2_sum[0] = 0.0;
+          }
+          block.sync();
+          atomicAdd(l2_sum, sum * sum);
+          block.sync();
+          TValue l2_norm = sqrtf(l2_sum[0]);
+          if (l2_norm > max_norm) {
+            sum *= max_norm / l2_norm;
+          }
+        }
+        out += sum * sp_weights;
+      }
+
+      out = Combine<combiner>(out, feature_num);
+      args[ev_id].emb_vector_[bid * dimension + tid] = out;
+    }
+  }
+}
+
+template <typename TKey, typename TValue, Combiner combiner>
+__global__ void NormalWeightedVariableComputeFn(
+    const int batch_size, const int emb_vec_size, const float max_norm,
+    const int num_lookups, GroupEmbeddingForWardArgs<TKey, TValue>* args) {
+  __shared__ TValue l2_sum[1];
+  const auto& block = cooperative_groups::this_thread_block();
+  // each block partition corresponding to one sample
+  const int bid = block.group_index().x;
+  // each thread corresponding to one element in the embedding vector
+  const int tid = block.thread_rank();
+
+  if (bid < batch_size && tid < emb_vec_size) {
+    for (int ev_id = 0; ev_id < num_lookups; ++ev_id) {
+      int value_offset = args[ev_id].offset_indices_[bid];
+      int feature_num;
+      if (bid == (batch_size - 1)) {
+        feature_num = args[ev_id].nnz_ - value_offset;
+      } else {
+        feature_num = args[ev_id].offset_indices_[bid + 1] - value_offset;
+      }
+      TValue out = 0.0f;
+
+      const TValue* emb_variable = args[ev_id].emb_variable_;
+      const int64_t emb_dim_limit = args[ev_id].emb_row_size_;
+      // #pragma unroll
+      for (int i = 0; i < feature_num; i++) {
+        int indices = int(args[ev_id].sp_values_[value_offset + i]);
+        TValue emb_element = emb_variable[indices * emb_vec_size + tid];
+        TValue sp_weights =
+            args[ev_id].sp_weights_[indices * emb_vec_size + tid];
+        // printf("indices is %d emb_element is %f\n", indices, emb_element);
+        if (max_norm >= 0.0f) {
+          // calc l2 norm of this emb row(per block) and compare with
+          // max_norm.
+          // if greater than max_norm, then clip every element with factor
+          // max_norm / l2norm
+          if (tid == 0) {
+            l2_sum[0] = 0.0f;
+          }
+          block.sync();
+          atomicAdd(l2_sum, emb_element * emb_element);
+          block.sync();
+          TValue l2_norm = sqrtf(l2_sum[0]);
+          if (l2_norm > max_norm) {
+            emb_element *= max_norm / l2_norm;
+          }
+        }
+        out += emb_element * sp_weights;
+      }
+      out = Combine<combiner>(out, feature_num);
+      args[ev_id].emb_vector_[bid * emb_vec_size + tid] = out;
+    }
+  }
+}
+
+template <typename TKey, typename TValue>
+class GroupEmbeddingLookupForWard {
+ public:
+  void initialize(const int num_lookups, const int dimension,
+                  const float max_norm) {
+    max_norm_ = max_norm;
+    dimension_ = dimension;
+    ev_nums_ = num_lookups;
+    args_size_ = sizeof(GroupEmbeddingForWardArgs<TKey, TValue>);
+    CK_CUDA_THROW_(cudaMalloc(&d_args_, args_size_ * num_lookups));
+    h_args_.resize(ev_nums_);
+  }
+
+  ~GroupEmbeddingLookupForWard() {
+    if (d_args_) {
+      CK_CUDA_THROW_(cudaFree(d_args_));
+    }
+  }
+
+  void set(int idx, TValue* emb_variable, TValue* emb_vector,
+           int* offset_indices, int nnz, TValue* sp_weights,
+           TKey* sp_values = nullptr, int emb_row_size = -1) {
+    h_args_[idx].emb_variable_ = emb_variable;
+    h_args_[idx].emb_vector_ = emb_vector;
+    h_args_[idx].offset_indices_ = offset_indices;
+    h_args_[idx].nnz_ = nnz;
+    h_args_[idx].sp_weights_ = sp_weights;
+    h_args_[idx].sp_values_ = sp_values;
+    h_args_[idx].emb_row_size_ = emb_row_size;
+  }
+
+  template <typename ForwardFn>
+  void Lookup(ForwardFn compute_fn, const int batch_size, const int tile_size,
+              cudaStream_t stream) {
+    CK_CUDA_THROW_(cudaMemcpyAsync(d_args_, h_args_.data(),
+                                   ev_nums_ * args_size_,
+                                   cudaMemcpyHostToDevice, stream));
+
+    {
+      // TODO: double check why mapped 2D grid slower
+      const int block_size = (batch_size - 1) / 64 * tile_size + 1;
+      compute_fn<<<block_size, 64, 0, stream>>>(batch_size, dimension_,
+                                                max_norm_, ev_nums_, d_args_);
+    }
+
+    CK_CUDA_THROW_(cudaGetLastError());
+  }
+
+ protected:
+  std::vector<GroupEmbeddingForWardArgs<TKey, TValue>> h_args_;
+  GroupEmbeddingForWardArgs<TKey, TValue>* d_args_{nullptr};
+  float max_norm_{0.0f};
+  int ev_nums_{0};
+  int dimension_{0};
+  size_t args_size_{0};
+};
+
+template <typename TKey, typename TValue>
+class GroupEmbeddingLookupForwardBaseOp : public OpKernel {
+ public:
+  explicit GroupEmbeddingLookupForwardBaseOp(OpKernelConstruction* c)
+      : OpKernel(c) {
+    OP_REQUIRES_OK(c, c->GetAttr("combiner", &combiner_));
+    OP_REQUIRES_OK(c, c->GetAttr("num_lookups", &num_lookups_));
+    OP_REQUIRES_OK(c, c->GetAttr("dimension", &dimension_));
+    OP_REQUIRES_OK(c, c->GetAttr("max_norm", &max_norm_));
+    OP_REQUIRES_OK(c, c->GetAttr("ignore_weights", &ignore_weights_));
+    lookuper_.initialize(num_lookups_, dimension_, max_norm_);
+  }
+
+  template <bool isEv, Combiner combiner>
+  inline void compute(const int batch_size, cudaStream_t stream) {
+    if (isEv) {
+      if (ignore_weights_) {
+        if (dimension_ <= 2) {
+          lookuper_.Lookup(EmbeddingVarComputeFn<TKey, TValue, combiner, 2>,
+                           batch_size, 2, stream);
+        } else if (dimension_ <= 4) {
+          lookuper_.Lookup(EmbeddingVarComputeFn<TKey, TValue, combiner, 4>,
+                           batch_size, 4, stream);
+        } else if (dimension_ <= 8) {
+          lookuper_.Lookup(EmbeddingVarComputeFn<TKey, TValue, combiner, 8>,
+                           batch_size, 8, stream);
+        } else if (dimension_ <= 16) {
+          lookuper_.Lookup(EmbeddingVarComputeFn<TKey, TValue, combiner, 16>,
+                           batch_size, 16, stream);
+        } else if (dimension_ <= 32) {
+          lookuper_.Lookup(EmbeddingVarComputeFn<TKey, TValue, combiner, 32>,
+                           batch_size, 32, stream);
+        } else {
+          lookuper_.Lookup(NormalEmbeddingVarComputeFn<TKey, TValue, combiner>,
+                           batch_size, 64, stream);
+        }
+      } else {
+        if (dimension_ <= 2) {
+          lookuper_.Lookup(
+              WeightedEmbeddingVarComputeFn<TKey, TValue, combiner, 2>,
+              batch_size, 2, stream);
+        } else if (dimension_ <= 4) {
+          lookuper_.Lookup(
+              WeightedEmbeddingVarComputeFn<TKey, TValue, combiner, 4>,
+              batch_size, 4, stream);
+        } else if (dimension_ <= 8) {
+          lookuper_.Lookup(
+              WeightedEmbeddingVarComputeFn<TKey, TValue, combiner, 8>,
+              batch_size, 8, stream);
+        } else if (dimension_ <= 16) {
+          lookuper_.Lookup(
+              WeightedEmbeddingVarComputeFn<TKey, TValue, combiner, 16>,
+              batch_size, 16, stream);
+        } else if (dimension_ <= 32) {
+          lookuper_.Lookup(
+              WeightedEmbeddingVarComputeFn<TKey, TValue, combiner, 32>,
+              batch_size, 32, stream);
+        } else {
+          lookuper_.Lookup(
+              NormalWeightedEmbeddingVarComputeFn<TKey, TValue, combiner>,
+              batch_size, 64, stream);
+        }
+      }
+    } else {
+      if (ignore_weights_) {
+        if (dimension_ <= 2) {
+          lookuper_.Lookup(VariableComputeFn<TKey, TValue, combiner, 2>,
+                           batch_size, 2, stream);
+        } else if (dimension_ <= 4) {
+          lookuper_.Lookup(VariableComputeFn<TKey, TValue, combiner, 4>,
+                           batch_size, 4, stream);
+        } else if (dimension_ <= 8) {
+          lookuper_.Lookup(VariableComputeFn<TKey, TValue, combiner, 8>,
+                           batch_size, 8, stream);
+        } else if (dimension_ <= 16) {
+          lookuper_.Lookup(VariableComputeFn<TKey, TValue, combiner, 16>,
+                           batch_size, 16, stream);
+        } else if (dimension_ <= 32) {
+          lookuper_.Lookup(VariableComputeFn<TKey, TValue, combiner, 32>,
+                           batch_size, 32, stream);
+        } else {
+          lookuper_.Lookup(NormalVariableComputeFn<TKey, TValue, combiner>,
+                           batch_size, 64, stream);
+        }
+      } else {
+        if (dimension_ <= 2) {
+          lookuper_.Lookup(WeightedVariableComputeFn<TKey, TValue, combiner, 2>,
+                           batch_size, 2, stream);
+        } else if (dimension_ <= 4) {
+          lookuper_.Lookup(WeightedVariableComputeFn<TKey, TValue, combiner, 4>,
+                           batch_size, 4, stream);
+        } else if (dimension_ <= 8) {
+          lookuper_.Lookup(WeightedVariableComputeFn<TKey, TValue, combiner, 8>,
+                           batch_size, 8, stream);
+        } else if (dimension_ <= 16) {
+          lookuper_.Lookup(
+              WeightedVariableComputeFn<TKey, TValue, combiner, 16>, batch_size,
+              16, stream);
+        } else if (dimension_ <= 32) {
+          lookuper_.Lookup(
+              WeightedVariableComputeFn<TKey, TValue, combiner, 32>, batch_size,
+              32, stream);
+        } else {
+          lookuper_.Lookup(
+              NormalWeightedVariableComputeFn<TKey, TValue, combiner>,
+              batch_size, 64, stream);
+        }
+      }
+    }
+  }
+
+ protected:
+  GroupEmbeddingLookupForWard<TKey, TValue> lookuper_;
+  std::string combiner_;
+  float max_norm_;
+  int num_lookups_;
+  int dimension_;
+  bool ignore_weights_;
+};
+
+}  // namespace
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA

--- a/tensorflow/python/ops/embedding_ops.py
+++ b/tensorflow/python/ops/embedding_ops.py
@@ -44,25 +44,20 @@ from tensorflow.python.util.tf_export import tf_export
 
 def _clip(params, ids, max_norm):
   """Helper function for _embedding_lookup_and_transform.
-
   This function optionally clips embeddings to an l2-norm of max_norm.
-
   Args:
     params: A `Tensor` of embeddings retrieved by `gather`.
     ids: The `ids` argument that was passed to `gather`.
     max_norm: If not `None`, each embedding is clipped if its l2-norm is larger
       than this value.
-
   Returns:
     A `Tensor` with the same type as `params`.
   """
 
   def _rank(x):
     """Helper function to retrieve the rank of a tensor.
-
     Args:
       x: Something convertible to `Tensor`.
-
     Returns:
       Either a pair `(rank, True)` where `rank` is an integer or a pair
       `(rank, False)` where `rank` is an integer `Tensor`. In either case,
@@ -104,7 +99,6 @@ def _embedding_lookup_and_transform(params,
                                     blocknums=None,
                                     counts=None):
   """Helper function for embedding_lookup and _compute_sampled_logits.
-
   This function is a generalization of embedding_lookup that optionally
   applies a caller-specified transformation to each embedding. This is
   done through the `transform_fn` argument. If provided, the function is
@@ -114,7 +108,6 @@ def _embedding_lookup_and_transform(params,
   `Tensor`. The shape of the argument will be the same as `params` except
   for the size of the first dimension. The first dimension of the result's
   shape must be the same size as the argument's.
-
   Args:
     params: See embedding_lookup.
     ids: See embedding_lookup.
@@ -124,7 +117,6 @@ def _embedding_lookup_and_transform(params,
     transform_fn: An optional function to apply to each retrieved embedding. If
       max_norm is provided, transform_fn is applied to the norm-limited
       embeddings.
-
   Returns:
     See embedding_lookup for details.
   Raises:
@@ -370,7 +362,6 @@ def embedding_lookup(
     blocknums=None,
     counts=None):
   """Looks up `ids` in a list of embedding tensors.
-
   This function is used to perform parallel lookups on the list of
   tensors in `params`.  It is a generalization of
   `tf.gather`, where `params` is
@@ -378,25 +369,20 @@ def embedding_lookup(
   a `PartitionedVariable` as returned by using `tf.compat.v1.get_variable()`
   with a
   partitioner.
-
   If `len(params) > 1`, each element `id` of `ids` is partitioned between
   the elements of `params` according to the `partition_strategy`.
   In all strategies, if the id space does not evenly divide the number of
   partitions, each of the first `(max_id + 1) % len(params)` partitions will
   be assigned one more id.
-
   If `partition_strategy` is `"mod"`, we assign each id to partition
   `p = id % len(params)`. For instance,
   13 ids are split across 5 partitions as:
   `[[0, 5, 10], [1, 6, 11], [2, 7, 12], [3, 8], [4, 9]]`
-
   If `partition_strategy` is `"div"`, we assign ids to partitions in a
   contiguous manner. In this case, 13 ids are split across 5 partitions as:
   `[[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10], [11, 12]]`
-
   The results of the lookup are concatenated into a dense
   tensor. The returned tensor has shape `shape(ids) + shape(params)[1:]`.
-
   Args:
     params: A single tensor representing the complete embedding tensor, or a
       list of P tensors all of same shape except for the first dimension,
@@ -415,10 +401,8 @@ def embedding_lookup(
       include raising an error.
     max_norm: If not `None`, each embedding is clipped if its l2-norm is larger
       than this value.
-
   Returns:
     A `Tensor` with the same type as the tensors in `params`.
-
   Raises:
     ValueError: If `params` is empty.
   """
@@ -437,7 +421,6 @@ def embedding_lookup(
 @tf_export("nn.embedding_lookup", v1=[])
 def embedding_lookup_v2(params, ids, max_norm=None, name=None):
   """Looks up `ids` in a list of embedding tensors.
-
   This function is used to perform parallel lookups on the list of
   tensors in `params`.  It is a generalization of
   `tf.gather`, where `params` is
@@ -445,21 +428,17 @@ def embedding_lookup_v2(params, ids, max_norm=None, name=None):
   a `PartitionedVariable` as returned by using `tf.compat.v1.get_variable()`
   with a
   partitioner.
-
   If `len(params) > 1`, each element `id` of `ids` is partitioned between
   the elements of `params` according to the `partition_strategy`.
   In all strategies, if the id space does not evenly divide the number of
   partitions, each of the first `(max_id + 1) % len(params)` partitions will
   be assigned one more id.
-
   The `partition_strategy` is always `"div"` currently. This means that we
   assign ids to partitions in a contiguous manner. For instance, 13 ids are
   split across 5 partitions as:
   `[[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10], [11, 12]]`
-
   The results of the lookup are concatenated into a dense
   tensor. The returned tensor has shape `shape(ids) + shape(params)[1:]`.
-
   Args:
     params: A single tensor representing the complete embedding tensor, or a
       list of P tensors all of same shape except for the first dimension,
@@ -471,10 +450,8 @@ def embedding_lookup_v2(params, ids, max_norm=None, name=None):
     max_norm: If not `None`, each embedding is clipped if its l2-norm is larger
       than this value.
     name: A name for the operation (optional).
-
   Returns:
     A `Tensor` with the same type as the tensors in `params`.
-
   Raises:
     ValueError: If `params` is empty.
   """
@@ -502,14 +479,11 @@ def embedding_lookup_sparse(params,
                             max_norm=None,
                             blocknums=None):
   """Computes embeddings for the given ids and weights.
-
   This op assumes that there is at least one id for each row in the dense tensor
   represented by sp_ids (i.e. there are no rows with empty features), and that
   all the indices of sp_ids are in canonical row-major order.
-
   It also assumes that all id values lie in the range [0, p0), where p0
   is the sum of the size of params along dimension 0.
-
   Args:
     params: A single tensor representing the complete embedding tensor, or a
       list of P tensors all of same shape except for the first dimension,
@@ -532,42 +506,30 @@ def embedding_lookup_sparse(params,
       sum of the squares of the weights.
     max_norm: If not `None`, each embedding is clipped if its l2-norm is larger
       than this value, before combining.
-
   Returns:
     A dense tensor representing the combined embeddings for the
     sparse ids. For each row in the dense tensor represented by `sp_ids`, the op
     looks up the embeddings for all ids in that row, multiplies them by the
     corresponding weight, and combines these embeddings as specified.
-
     In other words, if
-
       `shape(combined params) = [p0, p1, ..., pm]`
-
     and
-
       `shape(sp_ids) = shape(sp_weights) = [d0, d1, ..., dn]`
-
     then
-
       `shape(output) = [d0, d1, ..., dn-1, p1, ..., pm]`.
-
     For instance, if params is a 10x20 matrix, and sp_ids / sp_weights are
-
       ```python
       [0, 0]: id 1, weight 2.0
       [0, 1]: id 3, weight 0.5
       [1, 0]: id 0, weight 1.0
       [2, 3]: id 1, weight 3.0
       ```
-
     with `combiner`="mean", then the output will be a 3x20 matrix where
-
       ```python
       output[0, :] = (params[1, :] * 2.0 + params[3, :] * 0.5) / (2.0 + 0.5)
       output[1, :] = (params[0, :] * 1.0) / 1.0
       output[2, :] = (params[1, :] * 3.0) / 3.0
       ```
-
   Raises:
     TypeError: If `sp_ids` is not a `SparseTensor`, or if `sp_weights` is
       neither `None` nor `SparseTensor`.
@@ -869,14 +831,11 @@ def embedding_lookup_sparse_v2(params,
                                max_norm=None,
                                name=None):
   """Computes embeddings for the given ids and weights.
-
   This op assumes that there is at least one id for each row in the dense tensor
   represented by sp_ids (i.e. there are no rows with empty features), and that
   all the indices of sp_ids are in canonical row-major order.
-
   It also assumes that all id values lie in the range [0, p0), where p0
   is the sum of the size of params along dimension 0.
-
   Args:
     params: A single tensor representing the complete embedding tensor, or a
       list of P tensors all of same shape except for the first dimension,
@@ -896,42 +855,30 @@ def embedding_lookup_sparse_v2(params,
     max_norm: If not `None`, each embedding is clipped if its l2-norm is larger
       than this value, before combining.
     name: Optional name for the op.
-
   Returns:
     A dense tensor representing the combined embeddings for the
     sparse ids. For each row in the dense tensor represented by `sp_ids`, the op
     looks up the embeddings for all ids in that row, multiplies them by the
     corresponding weight, and combines these embeddings as specified.
-
     In other words, if
-
       `shape(combined params) = [p0, p1, ..., pm]`
-
     and
-
       `shape(sp_ids) = shape(sp_weights) = [d0, d1, ..., dn]`
-
     then
-
       `shape(output) = [d0, d1, ..., dn-1, p1, ..., pm]`.
-
     For instance, if params is a 10x20 matrix, and sp_ids / sp_weights are
-
       ```python
       [0, 0]: id 1, weight 2.0
       [0, 1]: id 3, weight 0.5
       [1, 0]: id 0, weight 1.0
       [2, 3]: id 1, weight 3.0
       ```
-
     with `combiner`="mean", then the output will be a 3x20 matrix where
-
       ```python
       output[0, :] = (params[1, :] * 2.0 + params[3, :] * 0.5) / (2.0 + 0.5)
       output[1, :] = (params[0, :] * 1.0) / 1.0
       output[2, :] = (params[1, :] * 3.0) / 3.0
       ```
-
   Raises:
     TypeError: If `sp_ids` is not a `SparseTensor`, or if `sp_weights` is
       neither `None` nor `SparseTensor`.
@@ -952,7 +899,6 @@ def embedding_lookup_sparse_multi_dim(params,
                                       weight_axis=-1):
   """Computes embeddings for the given ids and weights like
      embedding_lookup_sparse.
-
   Args:
     params: A single tensor representing the complete embedding tensor, or a
       list of P tensors all of same shape except for the first dimension,
@@ -973,13 +919,11 @@ def embedding_lookup_sparse_multi_dim(params,
       than this value, before combining.
     name: Optional name for the op.
     weight_axis: Specify axis to use weight.
-
   Returns:
     A dense tensor representing the combined embeddings for the
     sparse ids. For each row in the dense tensor represented by `sp_ids`, the op
     looks up the embeddings for all ids in that row, multiplies them by the
     corresponding weight, and combines these embeddings as specified.
-
   Raises:
     TypeError: If `sp_ids` is not a `SparseTensor`, or if `sp_weights` is
       neither `None` nor `SparseTensor`.
@@ -1167,25 +1111,20 @@ def safe_embedding_lookup_sparse_v2(embedding_weights,
                                     max_norm=None,
                                     name=None):
   """Lookup embedding results, accounting for invalid IDs and empty features.
-
   The partitioned embedding in `embedding_weights` must all be the same shape
   except for the first dimension. The first dimension is allowed to vary as the
   vocabulary size is not necessarily a multiple of `P`.  `embedding_weights`
   may be a `PartitionedVariable` as returned by using
   `tf.compat.v1.get_variable()` with a
   partitioner.
-
   Invalid IDs (< 0) are pruned from input IDs and weights, as well as any IDs
   with non-positive weight. For an entry with no features, the embedding vector
   for `default_id` is returned, or the 0-vector if `default_id` is not supplied.
-
   The ids and weights may be multi-dimensional. Embeddings are always aggregated
   along the last dimension.
-
   Note: when doing embedding lookup on `embedding_weights`, "div" partition
   strategy will be used. Support for other partition strategy will be added
   later.
-
   Args:
     embedding_weights:  A list of `P` float `Tensor`s or values representing
       partitioned embedding `Tensor`s.  Alternatively, a `PartitionedVariable`
@@ -1204,10 +1143,8 @@ def safe_embedding_lookup_sparse_v2(embedding_weights,
     max_norm: If not `None`, all embeddings are l2-normalized to max_norm before
       combining.
     name: A name for this operation (optional).
-
   Returns:
     Dense `Tensor` of shape `[d_0, d_1, ..., d_{n-1}, e_1, ..., e_m]`.
-
   Raises:
     ValueError: if `embedding_weights` is empty.
   """
@@ -1233,21 +1170,17 @@ def safe_embedding_lookup_sparse(embedding_weights,
                                  max_norm=None,
                                  prune=True):
   """Lookup embedding results, accounting for invalid IDs and empty features.
-
   The partitioned embedding in `embedding_weights` must all be the same shape
   except for the first dimension. The first dimension is allowed to vary as the
   vocabulary size is not necessarily a multiple of `P`.  `embedding_weights`
   may be a `PartitionedVariable` as returned by using
   `tf.compat.v1.get_variable()` with a
   partitioner.
-
   Invalid IDs (< 0) are pruned from input IDs and weights, as well as any IDs
   with non-positive weight. For an entry with no features, the embedding vector
   for `default_id` is returned, or the 0-vector if `default_id` is not supplied.
-
   The ids and weights may be multi-dimensional. Embeddings are always aggregated
   along the last dimension.
-
   Args:
     embedding_weights:  A list of `P` float `Tensor`s or values representing
       partitioned embedding `Tensor`s.  Alternatively, a `PartitionedVariable`
@@ -1268,10 +1201,8 @@ def safe_embedding_lookup_sparse(embedding_weights,
       `"div"` and `"mod"` are supported. Default is `"div"`.
     max_norm: If not `None`, all embeddings are l2-normalized to max_norm before
       combining.
-
   Returns:
     Dense `Tensor` of shape `[d_0, d_1, ..., d_{n-1}, e_1, ..., e_m]`.
-
   Raises:
     ValueError: if `embedding_weights` is empty.
   """
@@ -1584,7 +1515,6 @@ def safe_adaptive_embedding_lookup_sparse(hash_embedding_weights,
   '''
   if not isinstance(embedding_weights[0],
       (kv_variable_ops.EmbeddingVariable, kv_variable_ops.DynamicEmbeddingVariable)):
-
   '''
   with ops.name_scope(name, "embedding_lookup",
                       hash_embedding_weights + [sparse_ids,
@@ -1653,6 +1583,7 @@ def safe_adaptive_embedding_lookup_sparse(hash_embedding_weights,
 def group_embedding_lookup_sparse(params,
                                   sp_ids,
                                   combiners,
+                                  sp_weights=None,
                                   partition_strategy="mod",
                                   name=None):
   """
@@ -1672,7 +1603,6 @@ def group_embedding_lookup_sparse(params,
     emb_vec: list
             a list of tf.Tensor(the results of lookup).
   """
-  ##TODO(jqh): support calculate sp_weights in this API
   if combiners is None:
     logging.warn("The default value of combiner will change from \"mean\" "
                  "to \"sqrtn\" after 2016/11/01.")
@@ -1687,11 +1617,16 @@ def group_embedding_lookup_sparse(params,
     raise ValueError("params must be specified")
   if not isinstance(params, list):
     params = [params]
-  
+
+  ignore_weights = sp_weights is None
+
   if len(combiners) != len(sp_ids):
     raise ValueError("len of combiners must be equal to len of sp_ids")
   if len(combiners) != len(params):
     raise ValueError("len of combiners must be equal to len of params")
+  if not ignore_weights:
+    if len(combiners) != len(sp_weights):
+      raise ValueError("len of combiners must be equal to len of sp_weights")
 
   ## Currently not doing unique
   strategy = group_embedding_ops_utils.get_group_lookup_strategy()
@@ -1721,6 +1656,7 @@ def group_embedding_lookup_sparse(params,
     tf_group_id = 0
     is_ev_list = [False for _ in range(len(params))]
     params_idx_map = {}
+    batch_size = -1
 
     for index, param in enumerate(params):
       params_idx_map[param] = index
@@ -1730,7 +1666,19 @@ def group_embedding_lookup_sparse(params,
           sp_id = sp_id.to_sparse()
         except:  
           raise ValueError("sp_id is neither SparseTensor nor RaggedTensor!")
+      batch_size = math_ops.cast(sp_id.dense_shape[0], dtype=dtypes.int32)
 
+      if not ignore_weights:
+        sp_weight = sp_weights[index]
+        if sp_weight is not None:
+          if not isinstance(sp_weight, sparse_tensor.SparseTensor):
+            raise TypeError("sp_weights must be either None or SparseTensor")
+          sp_id.values.get_shape().assert_is_compatible_with(
+            sp_weight.values.get_shape())
+          sp_id.indices.get_shape().assert_is_compatible_with(
+              sp_weight.indices.get_shape())
+          sp_id.dense_shape.get_shape().assert_is_compatible_with(
+              sp_weight.dense_shape.get_shape())
 
       if isinstance(param, kv_variable_ops.EmbeddingVariable):
         is_ev_list[index] = True
@@ -1747,7 +1695,7 @@ def group_embedding_lookup_sparse(params,
     if ev_group_id > 0:
       ev_sp_values = [[] for _ in range(ev_group_id)]
       ev_sp_indices = [[] for _ in range(ev_group_id)]
-      ev_sp_dense_shape = [[] for _ in range(ev_group_id)]
+      ev_sp_weights = [[] for _ in range(ev_group_id)]
       ev_handlers = [[] for _ in range(ev_group_id)]
       ev_dimensions = [0 for _ in range(ev_group_id)]
       ev_combiners = ["mean" for _ in range(ev_group_id)]
@@ -1762,15 +1710,18 @@ def group_embedding_lookup_sparse(params,
         sp_id = sp_ids[index]
         batch_size = math_ops.cast(sp_id.dense_shape[0], dtype=dtypes.int32)
         combiner = combiners[index]
-
+        
         ev_combiners[group_id] = combiner
         ev_dimensions[group_id] = dim
         ev_handlers[group_id].append(param.handle)
         ev_sp_values[group_id].append(sp_id.values)
-        ev_sp_indices[group_id].append(sp_id.indices)
-        ev_sp_dense_shape[group_id].append(sp_id.dense_shape)
+        ev_sp_indices[group_id].append(sp_id.indices[:, 0])
         output_index_list[group_id].append(params_idx_map[param])
-      
+
+        if not ignore_weights:
+          sp_weight = sp_weights[index]
+          ev_sp_weights[group_id].append(sp_weight.values)
+
       for group_id in range(ev_group_id):
         dim = ev_dimensions[group_id]
         output_index = output_index_list[group_id]
@@ -1779,16 +1730,18 @@ def group_embedding_lookup_sparse(params,
           outputs = group_embedding_lookup_ops.group_embedding_var_lookup(ev_handlers[group_id],
                                                                           ev_sp_values[group_id],
                                                                           ev_sp_indices[group_id],
-                                                                          ev_sp_dense_shape[group_id],
+                                                                          ev_sp_weights[group_id],
                                                                           ev_combiners[group_id],
-                                                                          dim)[0]
+                                                                          batch_size,
+                                                                          dim,
+                                                                          ignore_weights)[0]
           for idx, output in zip(output_index, outputs):
             emb_vec[idx] = output
     
     if tf_group_id > 0:
       tf_sp_values = [[] for _ in range(tf_group_id)]
       tf_sp_indices = [[] for _ in range(tf_group_id)]
-      tf_sp_dense_shape = [[] for _ in range(tf_group_id)]
+      tf_sp_weights = [[] for _ in range(tf_group_id)]
       tf_handlers = [[] for _ in range(tf_group_id)]
       tf_dimensions = [0 for _ in range(tf_group_id)]
       tf_combiners = ["mean" for _ in range(tf_group_id)]
@@ -1807,10 +1760,13 @@ def group_embedding_lookup_sparse(params,
         tf_dimensions[group_id] = dim
         tf_handlers[group_id].append(param)
         tf_sp_values[group_id].append(sp_id.values)
-        tf_sp_indices[group_id].append(sp_id.indices)
-        tf_sp_dense_shape[group_id].append(sp_id.dense_shape)
+        tf_sp_indices[group_id].append(sp_id.indices[:, 0])
         output_index_list[group_id].append(params_idx_map[param])
-      
+
+        if not ignore_weights:
+          sp_weight = sp_weights[index]
+          tf_sp_weights[group_id].append(sp_weight.values)
+
       for group_id in range(tf_group_id):
         dim = tf_dimensions[group_id]
         output_index = output_index_list[group_id]
@@ -1819,9 +1775,11 @@ def group_embedding_lookup_sparse(params,
           outputs = group_embedding_lookup_ops.group_variable_lookup(tf_handlers[group_id],
                                                                       tf_sp_values[group_id],
                                                                       tf_sp_indices[group_id],
-                                                                      tf_sp_dense_shape[group_id],
+                                                                      tf_sp_weights[group_id],
                                                                       tf_combiners[group_id],
-                                                                      dim)[0]
+                                                                      batch_size,
+                                                                      dim,
+                                                                      ignore_weights)[0]
           for idx, output in zip(output_index, outputs):
             emb_vec[idx] = output
                                                                 

--- a/tensorflow/python/ops/group_embedding_lookup_ops.py
+++ b/tensorflow/python/ops/group_embedding_lookup_ops.py
@@ -1,5 +1,4 @@
 """Ops to use variables as resources."""
-# pylint: disable=g-bad-name
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -18,9 +17,11 @@ __all__ = ["group_embedding_var_lookup", "_GroupGatherGrad",
 def group_embedding_var_lookup(params,
                              sp_values,
                              sp_indices,
-                             sp_dense_shape,
+                             sp_weights,
                              combiners,
+                             batch_size,
                              dimensions,
+                             ignore_weights,
                              ev_init_value = None):
   if ev_init_value is not None:
     default_value = ev_init_value
@@ -28,14 +29,19 @@ def group_embedding_var_lookup(params,
   else:
     default_value = ops.convert_to_tensor(1.0)
     is_use_default_value_tensor = False
+  if ignore_weights:
+    sp_weight = ops.convert_to_tensor(1.0)
+    sp_weights = [sp_weight for _ in range(len(sp_values))]
   return gen_kv_variable_ops.group_embedding_var_lookup(params,
-                                                      sp_values,
-                                                      sp_indices,
-                                                      sp_dense_shape,
-                                                      default_value,
-                                                      combiners,
-                                                      dimensions,
-                                                      is_use_default_value_tensor)
+                                                        sp_values,
+                                                        sp_indices,
+                                                        sp_weights,
+                                                        batch_size,
+                                                        default_value,
+                                                        combiners,
+                                                        dimensions,
+                                                        ignore_weights,
+                                                        is_use_default_value_tensor)
 
 @ops.RegisterGradient("GroupEmbeddingVarLookup")
 def _GroupGatherGrad(op, *grads):
@@ -46,12 +52,12 @@ def _GroupGatherGrad(op, *grads):
   params = op.inputs[:ev_num]
   sp_values = op.inputs[ev_num:2*ev_num]
   sp_values_offset = op.outputs[ev_num:2*ev_num]
-  tmp_grads = gen_kv_variable_ops.multi_kv_resource_gather_grad(grads[:ev_num],
-                                                                params,
-                                                                sp_values,
-                                                                sp_values_offset,
-                                                                dimension,
-                                                                combiner)                                                            
+  tmp_grads = gen_kv_variable_ops.group_embedding_variable_lookup_grad(grads[:ev_num],
+                                                                      params,
+                                                                      sp_values,
+                                                                      sp_values_offset,
+                                                                      dimension,
+                                                                      combiner)                                                            
   for i in range(ev_num):
     handle = op.inputs[i]
     while handle.op.type != "KvVarHandleOp":
@@ -65,7 +71,7 @@ def _GroupGatherGrad(op, *grads):
     grad = array_ops.reshape(grad, values_shape)
     indice = array_ops.reshape(indice, size)
     return_grads.append(ops.IndexedSlices(grad, indice, params_shape))
-  for _ in range(ev_num*3 + 1):
+  for _ in range(ev_num*3 + 2):
     return_grads.append(None)
   return return_grads
   
@@ -73,9 +79,11 @@ def _GroupGatherGrad(op, *grads):
 def group_variable_lookup(params,
                           sp_values,
                           sp_indices,
-                          sp_dense_shape,
+                          sp_weights,
                           combiners,
+                          batch_size,
                           dimensions,
+                          ignore_weights,
                           default_id=None):
   if default_id is not None:
     default_value = default_id
@@ -84,14 +92,20 @@ def group_variable_lookup(params,
 
   is_use_default_value_tensor = True
 
+  if ignore_weights:
+    sp_weight = ops.convert_to_tensor(1.0)
+    sp_weights = [sp_weight for _ in range(len(sp_values))]
+    
   return gen_kv_variable_ops.group_variable_lookup(params,
                                                   sp_values,
                                                   sp_indices,
-                                                  sp_dense_shape,
+                                                  sp_weights,
+                                                  batch_size, 
                                                   default_value,
                                                   combiners,
                                                   dimensions,
-                                                  is_use_default_value_tensor)
+                                                  ignore_weights=ignore_weights,
+                                                  is_use_default_value_tensor=is_use_default_value_tensor)
 
 @ops.RegisterGradient("GroupVariableLookup")
 def _GroupEmbeddingLookup(op, *grads):
@@ -102,12 +116,12 @@ def _GroupEmbeddingLookup(op, *grads):
   params = op.inputs[:ev_num]
   sp_values = op.inputs[ev_num:2*ev_num]
   sp_values_offset = op.outputs[ev_num:2*ev_num]
-  tmp_grads = gen_kv_variable_ops.multi_embedding_sparse_look_up_grad(grads[:ev_num],
-                                                                      params,
-                                                                      sp_values,
-                                                                      sp_values_offset,
-                                                                      dimension,
-                                                                      combiner)
+  tmp_grads = gen_kv_variable_ops.group_variable_lookup_grad(grads[:ev_num],
+                                                            params,
+                                                            sp_values,
+                                                            sp_values_offset,
+                                                            dimension,
+                                                            combiner)
   for i in range(ev_num):
     params = op.inputs[i]
     with ops.colocate_with(params):
@@ -120,6 +134,6 @@ def _GroupEmbeddingLookup(op, *grads):
     grad = array_ops.reshape(grad, values_shape)
     indice = array_ops.reshape(indice, size)
     return_grads.append(ops.IndexedSlices(grad, indice, params_shape))
-  for _ in range(ev_num*3+1):
+  for _ in range(ev_num*3+2):
     return_grads.append(None)
   return return_grads


### PR DESCRIPTION
- Test performance based on DCNv2 increase from 13.4 step/s to 14.5 steps/s when batch_size is 8192.