### PR TITLE
[BUILD] Override default java toolchain to remove -parameters flag.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -111,6 +111,10 @@ build --define framework_shared_object=true
 build --define open_source_build=true
 test --define open_source_build=true
 
+# For workaround https://github.com/bazelbuild/bazel/issues/8772 with Bazel >= 0.29.1
+ build --java_toolchain=//third_party/toolchains/java:tf_java_toolchain
+ build --host_java_toolchain=//third_party/toolchains/java:tf_java_toolchain
+
 # Please note that OneDNN on MacOS or windows is still not supported.
 # If you would like to use a local OneDNN instead of downloading, please set the
 # environment variable "TF_MKL_ROOT" every time before build.

--- a/tensorflow/opensource_only.files
+++ b/tensorflow/opensource_only.files
@@ -205,6 +205,7 @@ tensorflow/third_party/toolchains/cpus/arm/arm_compiler_configure.bzl
 tensorflow/third_party/toolchains/cpus/arm/cc_config.bzl.tpl
 tensorflow/third_party/toolchains/cpus/py/BUILD
 tensorflow/third_party/toolchains/cpus/py3/BUILD
+tensorflow/third_party/toolchains/java/BUILD
 tensorflow/third_party/toolchains/preconfig/centos6/cuda10.0-cudnn7/cuda/BUILD
 tensorflow/third_party/toolchains/preconfig/centos6/cuda10.0-cudnn7/cuda/build_defs.bzl
 tensorflow/third_party/toolchains/preconfig/centos6/cuda10.1-cudnn7/cuda/BUILD

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2427,10 +2427,13 @@ def zeros_like_v2(
 def zeros_like_impl(tensor, dtype, name, optimize=True):
   """Internal implementation for the v1/v2 zeros_like API calls."""
   with ops.name_scope(name, "zeros_like", [tensor]) as name:
-    tensor = ops.convert_to_tensor(tensor, name="tensor")
+    if not tensor_util.is_tensor(tensor):
+      tensor = ops.convert_to_tensor(tensor, name="tensor")
+    tensor_shape = tensor.shape
+    tensor_dtype = tensor.dtype    
 
     if context.executing_eagerly():
-      if dtype is not None and dtype != tensor.dtype:
+      if dtype is not None and dtype != tensor_dtype:
         return zeros(
             shape_internal(tensor, optimize=optimize), dtype=dtype, name=name)
       with ops.device(tensor.device):
@@ -2439,13 +2442,13 @@ def zeros_like_impl(tensor, dtype, name, optimize=True):
     # For now, variant types must be created via zeros_like; as we need to
     # pass the input variant object to the proper zeros callback.
 
-    if (optimize and tensor.shape.is_fully_defined() and
-        tensor.dtype != dtypes.variant):
+    if (optimize and tensor_shape.is_fully_defined() and
+        tensor_dtype != dtypes.variant):
       # We can produce a zeros tensor independent of the value of 'tensor',
       # since the shape is known statically.
-      return zeros(tensor.shape, dtype=dtype or tensor.dtype, name=name)
+      return zeros(tensor_shape, dtype=dtype or tensor_dtype, name=name)
 
-    if dtype is not None and dtype != tensor.dtype and dtype != dtypes.variant:
+    if dtype is not None and dtype != tensor_dtype and dtype != dtypes.variant:
       return zeros(
           shape_internal(tensor, optimize=optimize), dtype=dtype, name=name)
     else:

--- a/third_party/toolchains/java/BUILD
+++ b/third_party/toolchains/java/BUILD
@@ -1,0 +1,18 @@
+# For workaround https://github.com/bazelbuild/bazel/issues/8772 with Bazel >= 0.29.1
+# TensorFlow still targets Java 1.7 (See JAVACOPTS in tensorflow/java/build_defs.bzl)
+# which doesn't support "-parameters" flag. Starting from Java 11 (default since Bazel
+# 0.29.1), a warning message will be thrown if "-parameters" is passed. If "-Werror" also exists,
+# the compiling action will fail. To workaround this, we override the misc value of
+# the default java toolchain to remove "-parameters" flag.
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+
+licenses(["notice"])
+
+default_java_toolchain(
+    name = "tf_java_toolchain",
+    misc = [
+        "-XDskipDuplicateBridges=true",
+        "-g",
+    ],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
For workaround bazelbuild/bazel#8772 with Bazel >= 0.29.1 TensorFlow still targets Java 1.7 (See JAVACOPTS), which doesn't support "-parameters" flag. Starting from Java 11 (default since Bazel 0.29.1), a warning
message will be thrown if "-parameters" is passed. If "-Werror" also exists,
the compiling action will fail. To workaround this, we override the misc value of
the default java toolchain to remove "-parameters" flag.