### PR TITLE
[Op] Implement TensorPackTransH2DOp to improve SmartStage Performance

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1730,6 +1730,7 @@ cc_library(
     ]) + if_cuda([
         "//tensorflow/core/grappler/optimizers:gpu_swapping_kernels",
         "//tensorflow/core/grappler/optimizers:gpu_swapping_ops",
+        "//tensorflow/core/kernels:tensor_pack_trans_ops"
     ]) + if_nccl([
         "//tensorflow/core/kernels:nccl_kernels",
     ]) + if_tensorrt([
@@ -3784,6 +3785,7 @@ tf_cuda_library(
         "common_runtime/gpu/gpu_util_platform_specific.cc",
         "common_runtime/gpu/gpu_device_placement_pass.cc",
         "common_runtime/gpu/gpu_stage_multi_stream_pass.cc",
+        "common_runtime/gpu/gpu_stage_pack_trans_pass.cc",
         "common_runtime/gpu/gpu_stage_subgraph_on_cpu_pass.cc"
     ],
     hdrs = GPU_RUNTIME_HEADERS,

--- a/tensorflow/core/common_runtime/gpu/gpu_stage_pack_trans_pass.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_stage_pack_trans_pass.cc
@@ -1,0 +1,146 @@
+/* Copyright 2023 The DeepRec Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA
+
+#include <unordered_set>
+#include <vector>
+
+#include "tensorflow/core/common_runtime/optimization_registry.h"
+#include "tensorflow/core/common_runtime/memory_types.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/graph/graph.h"
+#include "tensorflow/core/graph/graph_constructor.h"
+
+namespace tensorflow {
+
+class StagePackTransPass : public GraphOptimizationPass {
+ public:
+  Status Run(const GraphOptimizationPassOptions& options) override {
+    bool is_enable = false;
+    Status s;
+
+    s = ReadBoolFromEnvVar("ENABLE_STAGE_PACK_TRANS", false, &is_enable);
+    TF_CHECK_OK(s);
+    if (!is_enable)
+      return Status::OK();
+
+    VLOG(1) << "Run StagePackTrans Optimization";
+
+    Graph* graph = options.graph->get();
+    if (graph == nullptr)
+      return errors::Internal("a graph should be available.");
+    std::unique_ptr<Graph> new_graph(new Graph(OpRegistry::Global()));
+    CopyGraph(*graph, new_graph.get());
+
+    std::unordered_set<Node*> stage_nodes;
+    GetStageNodeOnGPU(new_graph, stage_nodes);
+
+    for (Node* n : stage_nodes) {
+      AddPackTransOp(new_graph, n);
+    }
+
+    options.graph->swap(new_graph);
+    return Status::OK();
+  }
+
+ private:
+  bool IsNodePlacedOnGPU(const Node* n) {
+    if (n->assigned_device_name().find("GPU") != std::string::npos)
+      return true;
+
+    return false;
+  }
+
+  void GetStageNodeOnGPU(const std::unique_ptr<Graph>& graph,
+                         std::unordered_set<Node*>& stage_nodes) {
+    for (Node* n : graph->op_nodes()) {
+      if (n->IsStage() && IsNodePlacedOnGPU(n)) {
+	stage_nodes.emplace(n);
+      }
+    }
+  }
+
+  void GetEdgeNeedH2D(std::unique_ptr<Graph>& graph, Node* stage_node,
+		      std::vector<const Edge*>& edges_vec,
+		      std::vector<DataType>& dtype_vec,
+		      std::vector<NodeDefBuilder::NodeOut>& src_list) {
+    Status s;
+    for (const Edge* e : stage_node->in_edges()) {
+      if (e->IsControlEdge())
+	continue;
+
+      Node* src_node = e->src();
+      // for src node placed on GPU, we need to check its output memtype.
+      if (IsNodePlacedOnGPU(src_node)) {
+	MemoryType src_output_memtype;
+        s = MemoryTypeForOutput(DEVICE_GPU, graph.get(), src_node,
+                                       e->src_output(), &src_output_memtype);
+	TF_CHECK_OK(s);
+
+	// skip the edge if src_output is already on device memory
+	if (src_output_memtype == DEVICE_MEMORY)
+	  continue;
+      }
+
+      // skip edge if src_output DataTypeSize is 0, because TensorPackTransH2DOp
+      // can not handle it.
+      DataType src_output_dtype = src_node->output_type(e->src_output());
+      if (DataTypeSize(src_output_dtype) == 0)
+	continue;
+
+      edges_vec.emplace_back(e);
+      dtype_vec.emplace_back(src_output_dtype);
+      src_list.emplace_back(src_node->name(), e->src_output(),
+                            src_output_dtype);
+    }
+  }
+
+  void AddPackTransOp(std::unique_ptr<Graph>& graph, Node* stage_node) {
+    // Find out the input edge which src output is placed on HOST_MEMORY
+    std::vector<const Edge*> edges_vec;
+    std::vector<DataType> dtype_vec;
+    std::vector<NodeDefBuilder::NodeOut> src_list;
+    GetEdgeNeedH2D(graph, stage_node, edges_vec, dtype_vec, src_list);
+    if (edges_vec.size() == 0)
+      return;
+
+    NodeDef pack_h2d_ndef;
+    std::string pack_h2d_name = stage_node->name() + "/TensorPackTransH2D";
+    TF_CHECK_OK(NodeDefBuilder(pack_h2d_name,  "_TensorPackTransH2D")
+		.Input(src_list)
+		.Device(stage_node->assigned_device_name())
+		.Attr("dtypes", DataTypeSlice(dtype_vec))
+		.Finalize(&pack_h2d_ndef));
+    Status s;
+    Node* pack_h2d_node = graph->AddNode(pack_h2d_ndef, &s);
+    TF_CHECK_OK(s);
+
+    // Update Edge
+    for (int i = 0; i < edges_vec.size(); i++) {
+      const Edge* e = edges_vec[i];
+      graph->AddEdge(e->src(), e->src_output(), pack_h2d_node, i);
+      graph->UpdateEdge(pack_h2d_node, i, stage_node, e->dst_input());
+    }
+  }
+};
+
+REGISTER_OPTIMIZATION(OptimizationPassRegistry::POST_PLACEMENT, 26,
+                      StagePackTransPass);
+
+} // end of namespace tensorflow
+
+#endif // end of GOOGLE_CUDA

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2846,6 +2846,15 @@ tf_kernel_library(
 )
 
 tf_kernel_library(
+    name = "tensor_pack_trans_ops",
+    srcs = ["tensor_pack_trans_ops.cc"],
+    deps=[
+        "//tensorflow/core:gpu_runtime",
+        "//tensorflow/core:proto_text"
+    ],
+)
+
+tf_kernel_library(
     name = "kv_variable_ops",
     hdrs = ["kv_variable_ops.h"],
     srcs = ["kv_variable_ops.cc",

--- a/tensorflow/core/kernels/tensor_pack_trans_ops.cc
+++ b/tensorflow/core/kernels/tensor_pack_trans_ops.cc
@@ -1,0 +1,111 @@
+/* Copyright 2023 The DeepRec Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifdef GOOGLE_CUDA
+
+#include <cstring>
+
+#include "tensorflow/core/common_runtime/gpu_device_context.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"
+#include "tensorflow/core/framework/allocator.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/util/work_sharder.h"
+
+namespace tensorflow {
+
+class TensorPackTransH2DOp : public OpKernel {
+ public:
+  explicit TensorPackTransH2DOp(OpKernelConstruction* ctx) : OpKernel(ctx) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    std::vector<size_t> tensor_offset_vec;
+    size_t total_bytes = 0;
+    for (int i = 0; i < ctx->num_inputs(); i++) {
+      const Tensor& input_tensor = ctx->input(i);
+      tensor_offset_vec.emplace_back(total_bytes);
+      total_bytes += AlignedBytes(input_tensor.TotalBytes());
+    }
+
+    // 1. pack input
+    Tensor merged_tensor_cpu;
+    TensorShape merged_tensor_shape;
+    AllocatorAttributes cpu_alloc_attr;
+    merged_tensor_shape.AddDim(total_bytes);
+    cpu_alloc_attr.set_on_host(true);
+    cpu_alloc_attr.set_gpu_compatible(true);
+    // Alloc pin memory
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_INT8, merged_tensor_shape,
+                                           &merged_tensor_cpu, cpu_alloc_attr));
+
+    auto merge_cpu_tensor = [this, ctx, &tensor_offset_vec, &merged_tensor_cpu](
+                                int64 start, int64 end) {
+      unsigned char* base =
+          reinterpret_cast<unsigned char*>(merged_tensor_cpu.data());
+      for (int i = start; i < end; i++) {
+	const Tensor& input_tensor = ctx->input(i);
+	size_t tensor_bytes = input_tensor.TotalBytes();
+        std::memcpy(base+tensor_offset_vec[i], input_tensor.data(),
+                    tensor_bytes);
+      }
+    };
+
+    auto worker_threads = ctx->device()->tensorflow_cpu_worker_threads();
+    int cost = 1000;
+    Shard(worker_threads->num_threads, worker_threads->workers,
+          ctx->num_inputs(), cost, merge_cpu_tensor);
+
+    // 2. MemcpyH2D
+    auto* dev_context = ctx->op_device_context();
+    se::Stream* compute_stream =
+        static_cast<const GPUDeviceContext*>(dev_context)->stream();
+
+    Tensor merged_tensor_gpu;
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_INT8, merged_tensor_shape,
+                                           &merged_tensor_gpu));
+    se::DeviceMemoryBase wrapped_dst(merged_tensor_gpu.data(), total_bytes);
+    compute_stream->ThenMemcpy(&wrapped_dst, merged_tensor_cpu.data(), total_bytes)
+        .ok();
+    compute_stream->BlockHostUntilDone();
+
+    // 3. UnPack
+    for(int i = 0; i < ctx->num_inputs(); i++) {
+      size_t offset = tensor_offset_vec[i];
+      Tensor tensor_slice =
+          merged_tensor_gpu.Slice(offset, offset + ctx->input(i).TotalBytes());
+      Tensor output(ctx->input(i).dtype());
+      output.BitcastFrom(tensor_slice, ctx->input(i).dtype(), ctx->input(i).shape());
+      ctx->set_output(i, output);
+    }
+  }
+
+ private:
+  size_t AlignedBytes(size_t s) {
+#if EIGEN_MAX_ALIGN_BYTES == 0
+    return s;
+#else
+    return std::ceil(s * 1.0 / EIGEN_MAX_ALIGN_BYTES) * EIGEN_MAX_ALIGN_BYTES;
+#endif
+  }
+};
+
+REGISTER_KERNEL_BUILDER(Name("_TensorPackTransH2D")
+                            .Device(DEVICE_GPU)
+                            .HostMemory("input_tensor_list"),
+                        TensorPackTransH2DOp);
+
+} // End of namespace tensorflow
+
+#endif // End of GOOGLE_CUDA


### PR DESCRIPTION
on GPU.

   1. This commit implements TensorPackTransH2DOp which can merge and transmit tensors located on the CPU to the GPU to improve transmission efficiency.

   2. This commit modifies the behavior of stage_subgraph_on_cpu optimization, placing the Stage and Unstage nodes on the GPU.

   3. This commit contains a pass that automatically adds TensorPackTransOp before the Stage node, controlled by the environment variable ENABLE_STAGE_PACK_TRANS, which is disabled by default.