### PR TITLE
[Embedding] Refactor the code related to EmbeddingConfig.

### DIFF
--- a/tensorflow/core/framework/embedding/bloom_filter_policy.h
+++ b/tensorflow/core/framework/embedding/bloom_filter_policy.h
@@ -196,7 +196,8 @@ class BloomFilterPolicy : public FilterPolicy<K, V, EV> {
                 int bucket_num,
                 int64 partition_id,
                 int64 partition_num,
-                bool is_filter) override {
+                bool is_filter,
+                int64 emb_index) override {
     K* key_buff = (K*)restore_buff.key_buffer;
     V* value_buff = (V*)restore_buff.value_buffer;
     int64* version_buff = (int64*)restore_buff.version_buffer;
@@ -234,7 +235,9 @@ class BloomFilterPolicy : public FilterPolicy<K, V, EV> {
         }
       }
     }
-    if (ev_->IsMultiLevel() && !ev_->IsUseHbm() && config_.is_primary()) {
+    if (ev_->IsMultiLevel() &&
+       !ev_->IsUseHbm() &&
+       config_.is_primary(emb_index)) {
       ev_->UpdateCache(key_buff, key_num, version_buff, freq_buff);
     }
     return Status::OK();
@@ -246,7 +249,8 @@ class BloomFilterPolicy : public FilterPolicy<K, V, EV> {
                 int64 partition_id,
                 int64 partition_num,
                 bool is_filter,
-                V* default_values) override {
+                V* default_value,
+                int64 default_value_dim) override {
     LOG(FATAL)<<"BloomFilter dosen't support ImportToDRAM";
     return Status::OK();
   }

--- a/tensorflow/core/framework/embedding/counter_filter_policy.h
+++ b/tensorflow/core/framework/embedding/counter_filter_policy.h
@@ -73,7 +73,8 @@ class CounterFilterPolicy : public FilterPolicy<K, V, EV> {
                 int bucket_num,
                 int64 partition_id,
                 int64 partition_num,
-                bool is_filter) override {
+                bool is_filter,
+                int64 emb_index) override {
     K* key_buff = (K*)restore_buff.key_buffer;
     V* value_buff = (V*)restore_buff.value_buffer;
     int64* version_buff = (int64*)restore_buff.version_buffer;
@@ -109,7 +110,9 @@ class CounterFilterPolicy : public FilterPolicy<K, V, EV> {
         }
       }
     }
-    if (ev_->IsMultiLevel() && !ev_->IsUseHbm() && config_.is_primary()) {
+    if (ev_->IsMultiLevel() &&
+       !ev_->IsUseHbm() &&
+       config_.is_primary(emb_index)) {
       ev_->UpdateCache(key_buff, key_num, version_buff, freq_buff);
     }
     return Status::OK();
@@ -121,7 +124,8 @@ class CounterFilterPolicy : public FilterPolicy<K, V, EV> {
                 int64 partition_id,
                 int64 partition_num,
                 bool is_filter,
-                V* default_values) override {
+                V* default_values,
+                int64 default_value_dim) override {
     K* key_buff = (K*)restore_buff.key_buffer;
     V* value_buff = (V*)restore_buff.value_buffer;
     int64* version_buff = (int64*)restore_buff.version_buffer;
@@ -154,7 +158,7 @@ class CounterFilterPolicy : public FilterPolicy<K, V, EV> {
         } else {
           ev_->LookupOrCreateEmb(value_ptr,
               default_values +
-                (key_buff[i] % config_.default_value_dim)
+                (key_buff[i] % default_value_dim)
                  * ev_->ValueLen(),
               ev_allocator());
         }

--- a/tensorflow/core/framework/embedding/dram_ssd_storage.h
+++ b/tensorflow/core/framework/embedding/dram_ssd_storage.h
@@ -177,6 +177,7 @@ class DramSsdHashStorage : public MultiTierStorage<K, V> {
       std::vector<V*>* value_list,
       std::vector<int64>* version_list,
       std::vector<int64>* freq_list,
+      int64 emb_index,
       const EmbeddingConfig& emb_config,
       SsdRecordDescriptor<K>* ssd_rec_desc) override {
     {
@@ -185,9 +186,8 @@ class DramSsdHashStorage : public MultiTierStorage<K, V> {
       std::vector<K> temp_key_list;
       TF_CHECK_OK(dram_kv_->GetSnapshot(&temp_key_list, &value_ptr_list));
       MultiTierStorage<K, V>::SetListsForCheckpoint(
-          temp_key_list, value_ptr_list, emb_config,
-          key_list, value_list, version_list,
-          freq_list);
+          temp_key_list, value_ptr_list, emb_index,
+          emb_config, key_list, value_list, version_list, freq_list);
     }
     {
       mutex_lock l(ssd_mu_);

--- a/tensorflow/core/framework/embedding/embedding_config.h
+++ b/tensorflow/core/framework/embedding/embedding_config.h
@@ -6,84 +6,40 @@
 
 namespace tensorflow {
 struct EmbeddingConfig {
-  int64 emb_index;
-  int64 primary_emb_index;
-  int64 block_num;
-  int64 slot_num;
-  std::string name;
-  int64 steps_to_live;
-  int64 filter_freq;
-  int64 max_freq;
-  float l2_weight_threshold;
-  int64 kHashFunc;
-  int64 num_counter;
-  DataType counter_type;
-  int64 default_value_dim;
-  float default_value_no_permission;
-  int normal_fix_flag;
-  bool record_freq;
-  bool record_version;
-
-  EmbeddingConfig(int64 emb_index = 0,
-                  int64 primary_emb_index = 0,
-                  int64 block_num = 1,
-                  int slot_num = 0,
-                  const std::string& name = "",
-                  int64 steps_to_live = 0,
-                  int64 filter_freq = 0,
-                  int64 max_freq = 999999,
-                  float l2_weight_threshold = -1.0,
-                  const std::string& layout = "normal",
-                  int64 max_element_size = 0,
-                  float false_positive_probability = -1.0,
-                  DataType counter_type = DT_UINT64,
-                  int64 default_value_dim = 4096,
-                  float default_value_no_permission = .0,
-                  bool record_freq =false,
-                  bool record_version=false):
-      emb_index(emb_index),
-      primary_emb_index(primary_emb_index),
-      block_num(block_num),
-      slot_num(slot_num),
-      name(name),
-      steps_to_live(steps_to_live),
-      filter_freq(filter_freq),
-      max_freq(max_freq),
-      l2_weight_threshold(l2_weight_threshold),
-      counter_type(counter_type),
-      default_value_dim(default_value_dim),
-      default_value_no_permission(default_value_no_permission),
-      normal_fix_flag(0),
-      record_freq(record_freq),
-      record_version(record_version) {
-    if (max_element_size != 0 && false_positive_probability != -1.0){
+  EmbeddingConfig(
+      int64 primary_emb_index, int64 block_num , int slot_num = 0,
+      int64 steps_to_live = 0, int64 filter_freq = 0, int64 max_freq = 999999,
+      float l2_weight_threshold = -1.0, const std::string& layout = "normal",
+      int64 max_element_size = 0, float false_positive_probability = -1.0,
+      DataType counter_type = DT_UINT64, float default_value_no_permission = .0,
+      bool record_freq = false, bool record_version = false)
+      : primary_emb_index(primary_emb_index),
+        block_num(block_num),
+        slot_num(slot_num),
+        steps_to_live(steps_to_live),
+        filter_freq(filter_freq),
+        max_freq(max_freq),
+        l2_weight_threshold(l2_weight_threshold),
+        counter_type(counter_type),
+        default_value_no_permission(default_value_no_permission),
+        normal_fix_flag(0),
+        record_freq(record_freq),
+        record_version(record_version) {
+    if (max_element_size != 0 && false_positive_probability != -1.0) {
       kHashFunc = calc_num_hash_func(false_positive_probability);
-      num_counter = calc_num_counter(max_element_size,
-          false_positive_probability);
+      num_counter =
+          calc_num_counter(max_element_size, false_positive_probability);
     } else {
       kHashFunc = 0;
       num_counter = 0;
     }
-    if (layout == "normal_contiguous" ||
-        layout == "normal_contiguous_gpu") {
+    if (layout == "normal_contiguous" || layout == "normal_contiguous_gpu") {
       normal_fix_flag = 1;
     }
   }
 
-  int64 calc_num_counter(int64 max_element_size,
-      float false_positive_probability) {
-    float loghpp = fabs(log(false_positive_probability));
-    float factor = log(2) * log(2);
-    int64 num_bucket = ceil(loghpp / factor * max_element_size);
-    if (num_bucket * sizeof(counter_type) > 10 * (1L << 30))
-      LOG(WARNING)<<"The Size of BloomFilter is more than 10GB!";
-    return num_bucket;
-  }
-
-  bool is_counter_filter(){
-    if (filter_freq !=0 &&
-         kHashFunc == 0 &&
-         num_counter == 0){
+  bool is_counter_filter() {
+    if (filter_freq != 0 && kHashFunc == 0 && num_counter == 0) {
       return true;
     } else {
       return false;
@@ -91,37 +47,52 @@ struct EmbeddingConfig {
   }
 
   int64 calc_num_hash_func(float false_positive_probability) {
-    float loghpp = fabs(log(false_positive_probability)/log(2));
+    float loghpp = fabs(log(false_positive_probability) / log(2));
     return ceil(loghpp);
   }
-  bool is_primary() const {
-    return emb_index == primary_emb_index;
-  }
+  bool is_primary(int64 emb_index) const { return emb_index == primary_emb_index; }
 
   int64 total_num(int alloc_len) {
-    return block_num *
-           (1 + (1 - normal_fix_flag) * slot_num) *
+    return block_num * (1 + (1 - normal_fix_flag) * slot_num) *
            (1 + normal_fix_flag * (alloc_len * (slot_num + 1) - 1));
   }
 
-  int64 get_filter_freq() {
-    return filter_freq;
-  }
+  int64 get_filter_freq() { return filter_freq; }
 
   std::string DebugString() const {
-    return strings::StrCat("opname: ", name,
-                           " emb_index: ", emb_index,
-                           " primary_emb_index: ", primary_emb_index,
-                           " block_num: ", block_num,
-                           " slot_num: ", slot_num,
-                           " steps_to_live: ", steps_to_live,
-                           " filter_freq: ", filter_freq,
-                           " max_freq: ", max_freq,
-                           " l2_weight_threshold: ", l2_weight_threshold);
+    return strings::StrCat(
+        " primary_emb_index: ", primary_emb_index, " block_num: ", block_num,
+        " slot_num: ", slot_num, " steps_to_live: ", steps_to_live,
+        " filter_freq: ", filter_freq, " max_freq: ", max_freq,
+        " l2_weight_threshold: ", l2_weight_threshold);
   }
+
+  int64 calc_num_counter(int64 max_element_size,
+                         float false_positive_probability) {
+    float loghpp = fabs(log(false_positive_probability));
+    float factor = log(2) * log(2);
+    int64 num_bucket = ceil(loghpp / factor * max_element_size);
+    if (num_bucket * sizeof(counter_type) > 10 * (1L << 30))
+      LOG(WARNING) << "The Size of BloomFilter is more than 10GB!";
+    return num_bucket;
+  }
+
+  int64 primary_emb_index;
+  int64 block_num;
+  int64 slot_num;
+  int64 steps_to_live;
+  int64 filter_freq;
+  int64 max_freq;
+  float l2_weight_threshold;
+  int64 kHashFunc;
+  int64 num_counter;
+  DataType counter_type;
+  float default_value_no_permission;
+  int normal_fix_flag;
+  bool record_freq;
+  bool record_version;
 };
 
-} // tensorflow
+}  // namespace tensorflow
 
-#endif // TENSORFLOW_CORE_FRAMEWORK_EMBEDDING_EMBEDDING_CONFIG_H_
-
+#endif  // TENSORFLOW_CORE_FRAMEWORK_EMBEDDING_EMBEDDING_CONFIG_H_

--- a/tensorflow/core/framework/embedding/embedding_var.cu.cc
+++ b/tensorflow/core/framework/embedding/embedding_var.cu.cc
@@ -66,7 +66,7 @@ void EmbeddingVar<K, V>::SetDefaultValueOfNewFeatures(
           reinterpret_cast<ValuePtr<V>*>(memcpy_address[*it]);
       value_address[i] =
           *((V**)((char*)(value_ptr->GetPtr()) + sizeof(FixedLengthHeader))) +
-          storage_manager_->GetOffset(emb_config_.emb_index);
+          storage_manager_->GetOffset(emb_index_);
       default_value_address[i] = get_default_v_fn(
           default_values, keys[*it], *it, GetDefaultValueDim(), ValueLen());
     }
@@ -83,10 +83,10 @@ void EmbeddingVar<K, V>::SetDefaultValueOfNewFeatures(
     for (auto it = init_cursor.cbegin(); it != init_cursor.cend(); ++it) {
       ValuePtr<V>* value_ptr =
           reinterpret_cast<ValuePtr<V>*>(memcpy_address[*it]);
-      value_ptr->SetInitialized(emb_config_.emb_index);
+      value_ptr->SetInitialized(emb_index_);
       memcpy_address[*it] = value_ptr->GetValue(
-          emb_config_.emb_index,
-          storage_manager_->GetOffset(emb_config_.emb_index));
+          emb_index_,
+          storage_manager_->GetOffset(emb_index_));
     }
     TypedAllocator::Deallocate(alloc_, dev_value_address, total * 2);
     TypedAllocator::Deallocate(cpu_allocator(), value_address, total * 2);
@@ -168,7 +168,7 @@ void EmbeddingVar<K, V>::CopyEmbeddingsFromCPUToGPU(
       bool init;
       // Get the curosr
       int64 cursor = *it & 0x0fffffffffffffff;
-      gpu_value_ptrs[i]->SetInitialized(emb_config_.emb_index);
+      gpu_value_ptrs[i]->SetInitialized(emb_index_);
       memcpy_address[cursor] = LookupOrCreateEmb(gpu_value_ptrs[i], init);
       value_address[i] = memcpy_address[cursor];
       copyback_keys[i] = keys[cursor];

--- a/tensorflow/core/framework/embedding/filter_policy.h
+++ b/tensorflow/core/framework/embedding/filter_policy.h
@@ -54,14 +54,16 @@ class FilterPolicy {
     int bucket_num,
     int64 partition_id,
     int64 partition_num,
-    bool is_filter) = 0;
+    bool is_filter,
+    int64 emb_index) = 0;
   virtual Status ImportToDram(RestoreBuffer& restore_buff,
                 int64 key_num,
                 int bucket_num,
                 int64 partition_id,
                 int64 partition_num,
                 bool is_filter,
-                V* default_values) = 0;
+                V* default_values,
+                int64 default_value_dim) = 0;
 };
 } // tensorflow
 

--- a/tensorflow/core/framework/embedding/hbm_dram_storage.h
+++ b/tensorflow/core/framework/embedding/hbm_dram_storage.h
@@ -360,6 +360,7 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
       std::vector<V* >* value_list,
       std::vector<int64>* version_list,
       std::vector<int64>* freq_list,
+      int64 emb_index,
       const EmbeddingConfig& emb_config,
       FilterPolicy<K, V, EmbeddingVar<K, V>>* filter,
       embedding::Iterator** it) override {
@@ -383,7 +384,7 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
                                     dram_value_ptr_list,
                                     Storage<K, V>::alloc_len_,
                                     gpu_alloc_,
-                                    emb_config.emb_index);
+                                    emb_index);
     // This return value is not the exact number of IDs
     // because the two tables intersect.
     return temp_hbm_key_list.size() + temp_dram_key_list.size();

--- a/tensorflow/core/framework/embedding/kv_interface.h
+++ b/tensorflow/core/framework/embedding/kv_interface.h
@@ -97,7 +97,8 @@ class KVInterface {
 
   virtual Iterator* GetIterator() { return nullptr; }
 
-  virtual Status BatchLookupOrCreate(const K* keys, V* val, V* default_v,
+  virtual Status BatchLookupOrCreate(const K* keys, V* val,
+      int64 emb_index, V* default_v,
       int32 default_v_num, bool is_use_default_value_tensor,
       size_t n, const Eigen::GpuDevice& device) {
     return Status::OK();

--- a/tensorflow/core/framework/embedding/multi_tier_storage.h
+++ b/tensorflow/core/framework/embedding/multi_tier_storage.h
@@ -109,6 +109,7 @@ class MultiTierStorage : public Storage<K, V> {
   void SetListsForCheckpoint(
       const std::vector<K>& input_key_list,
       const std::vector<ValuePtr<V>*>& input_value_ptr_list,
+      int64 emb_index,
       const EmbeddingConfig& emb_config,
       std::vector<K>* output_key_list,
       std::vector<V*>* output_value_list,
@@ -126,8 +127,8 @@ class MultiTierStorage : public Storage<K, V> {
         output_version_list->emplace_back(dump_version);
       }
 
-      V* val = input_value_ptr_list[i]->GetValue(emb_config.emb_index,
-          Storage<K, V>::GetOffset(emb_config.emb_index));
+      V* val = input_value_ptr_list[i]->GetValue(emb_index,
+          Storage<K, V>::GetOffset(emb_index));
       V* primary_val = input_value_ptr_list[i]->GetValue(
           emb_config.primary_emb_index,
           Storage<K, V>::GetOffset(emb_config.primary_emb_index));
@@ -152,6 +153,7 @@ class MultiTierStorage : public Storage<K, V> {
       std::vector<V* >* value_list,
       std::vector<int64>* version_list,
       std::vector<int64>* freq_list,
+      int64 emb_index,
       const EmbeddingConfig& emb_config,
       FilterPolicy<K, V, EmbeddingVar<K, V>>* filter,
       embedding::Iterator** it) override {
@@ -165,7 +167,7 @@ class MultiTierStorage : public Storage<K, V> {
         continue;
       }
       SetListsForCheckpoint(
-          key_list_tmp, value_ptr_list, emb_config,
+          key_list_tmp, value_ptr_list, emb_index, emb_config,
           key_list, value_list, version_list, freq_list);
     }
     return key_list->size();
@@ -176,6 +178,7 @@ class MultiTierStorage : public Storage<K, V> {
       std::vector<V* >* value_list,
       std::vector<int64>* version_list,
       std::vector<int64>* freq_list,
+      int64 emb_index,
       const EmbeddingConfig& emb_config,
       SsdRecordDescriptor<K>* ssd_rec_desc) override {
     LOG(FATAL)<<"The Storage dosen't use presisten memory"

--- a/tensorflow/core/framework/embedding/nullable_filter_policy.h
+++ b/tensorflow/core/framework/embedding/nullable_filter_policy.h
@@ -85,7 +85,8 @@ class NullableFilterPolicy : public FilterPolicy<K, V, EV> {
                 int bucket_num,
                 int64 partition_id,
                 int64 partition_num,
-                bool is_filter) override {
+                bool is_filter,
+                int64 emb_index) override {
     K* key_buff = (K*)restore_buff.key_buffer;
     V* value_buff = (V*)restore_buff.value_buffer;
     int64* version_buff = (int64*)restore_buff.version_buffer;
@@ -114,7 +115,9 @@ class NullableFilterPolicy : public FilterPolicy<K, V, EV> {
             ev_->GetDefaultValue(key_buff[i]));
       }
     }
-    if (ev_->IsMultiLevel() && !ev_->IsUseHbm() && config_.is_primary()) {
+    if (ev_->IsMultiLevel() &&
+       !ev_->IsUseHbm() &&
+       config_.is_primary(emb_index)) {
       ev_->UpdateCache(key_buff, key_num, version_buff, freq_buff);
     }
     return Status::OK();
@@ -126,7 +129,8 @@ class NullableFilterPolicy : public FilterPolicy<K, V, EV> {
                 int64 partition_id,
                 int64 partition_num,
                 bool is_filter,
-                V* default_values) override {
+                V* default_values,
+                int64 default_value_dim) override {
     K* key_buff = (K*)restore_buff.key_buffer;
     V* value_buff = (V*)restore_buff.value_buffer;
     int64* version_buff = (int64*)restore_buff.version_buffer;
@@ -153,7 +157,7 @@ class NullableFilterPolicy : public FilterPolicy<K, V, EV> {
       } else {
         ev_->LookupOrCreateEmb(value_ptr,
             default_values +
-                (key_buff[i] % config_.default_value_dim)
+                (key_buff[i] % default_value_dim)
                 * ev_->ValueLen(),
             ev_allocator());
       }

--- a/tensorflow/core/framework/embedding/storage.h
+++ b/tensorflow/core/framework/embedding/storage.h
@@ -92,6 +92,7 @@ class Storage {
       std::vector<V* >* value_list,
       std::vector<int64>* version_list,
       std::vector<int64>* freq_list,
+      int64 emb_index,
       const EmbeddingConfig& emb_config,
       FilterPolicy<K, V, EmbeddingVar<K, V>>* filter,
       embedding::Iterator** it) = 0;
@@ -100,6 +101,7 @@ class Storage {
       std::vector<V* >* value_list,
       std::vector<int64>* version_list,
       std::vector<int64>* freq_list,
+      int64 emb_index,
       const EmbeddingConfig& emb_config,
       SsdRecordDescriptor<K>* ssd_rec_desc) = 0;
   virtual void RestoreSsdHashmap(
@@ -126,14 +128,14 @@ class Storage {
       EventMgr* event_mgr,
       const DeviceBase::CpuWorkerThreads* worker_threads) = 0;
 
-  virtual void BatchLookupOrCreate(const K* key, V* val, V* default_v,
-      int32 default_v_num, bool is_use_default_value_tensor,
+  virtual void BatchLookupOrCreate(const K* key, V* val, int64 emb_index,
+      V* default_v, int32 default_v_num, bool is_use_default_value_tensor,
       size_t n, const Eigen::GpuDevice& device) {}
   virtual void BatchLookupOrCreateKeys(const K* key, int32* item_idxs, size_t n,
       const Eigen::GpuDevice& device) {}
   virtual void ImportToHbm(const std::vector<K>& keys,
       const std::vector<V>& values, const Eigen::GpuDevice* device,
-      const EmbeddingConfig& emb_config) {};
+      int64 emb_index) {};
   virtual GPUHashTable<K, V>* HashTable() {
     return nullptr;
   }

--- a/tensorflow/core/framework/embedding/storage_config.h
+++ b/tensorflow/core/framework/embedding/storage_config.h
@@ -21,13 +21,6 @@ limitations under the License.
 namespace tensorflow {
 namespace embedding {
 struct StorageConfig {
-  StorageConfig() : type(StorageType::DEFAULT),
-                    path(""),
-                    layout_type(LayoutType::NORMAL),
-                    cache_strategy(CacheStrategy::LFU) {
-    size = {1<<30,1<<30,1<<30,1<<30};
-  }
-
   StorageConfig(StorageType t,
                 const std::string& p,
                 const std::vector<int64>& s,
@@ -35,7 +28,9 @@ struct StorageConfig {
                 const EmbeddingConfig& ec,
                 const CacheStrategy cache_strategy_ = CacheStrategy::LFU)
                                       : type(t),
+                                        layout_type(LayoutType::NORMAL),
                                         path(p),
+                                        size(s),
                                         embedding_config(ec),
                                         cache_strategy(cache_strategy_) {
     if ("normal" == layout) {
@@ -53,14 +48,13 @@ struct StorageConfig {
         << layout << ", use LayoutType::NORMAL by default.";
       layout_type = LayoutType::NORMAL;
     }
-    size = s;
   }
   StorageType type;
   LayoutType layout_type;
   std::string path;
   std::vector<int64> size;
-  CacheStrategy cache_strategy;
   EmbeddingConfig embedding_config;
+  CacheStrategy cache_strategy;
 };
 } // namespace embedding
 } // namespace tensorflow

--- a/tensorflow/core/framework/embedding/storage_manager.h
+++ b/tensorflow/core/framework/embedding/storage_manager.h
@@ -183,10 +183,10 @@ class StorageManager {
     storage_->AllocateMemoryForNewFeatures(value_ptr_list, num_of_value_ptrs);
   }
 
-  void BatchLookupOrCreate(const K* key, V* val, V* default_v,
+  void BatchLookupOrCreate(const K* key, V* val, int64 emb_index, V* default_v,
       int32 default_v_num, bool is_use_default_value_tensor,
       size_t n, const Eigen::GpuDevice& device) {
-    storage_->BatchLookupOrCreate(key, val, default_v, default_v_num,
+    storage_->BatchLookupOrCreate(key, val, emb_index, default_v, default_v_num,
         is_use_default_value_tensor, n, device);
   }
 
@@ -197,8 +197,8 @@ class StorageManager {
 
   void ImportToHbm(const std::vector<K>& keys,
       const std::vector<V>& values, const Eigen::GpuDevice* device,
-      const EmbeddingConfig& emb_config) {
-    storage_->ImportToHbm(keys, values, device, emb_config);
+      int64 emb_index) {
+    storage_->ImportToHbm(keys, values, device, emb_index);
   }
 
 
@@ -225,11 +225,12 @@ class StorageManager {
       std::vector<V* >* value_list,
       std::vector<int64>* version_list,
       std::vector<int64>* freq_list,
+      int64 emb_index,
       const EmbeddingConfig& emb_config,
       FilterPolicy<K, V, EmbeddingVar<K, V>>* filter,
       embedding::Iterator** it) {
     return storage_->GetSnapshot(key_list, value_list, version_list,
-        freq_list, emb_config, filter, it);
+        freq_list, emb_index, emb_config, filter, it);
   }
 
   int64 GetSnapshotWithoutFetchPersistentEmb(
@@ -237,12 +238,13 @@ class StorageManager {
       std::vector<V* >* value_list,
       std::vector<int64>* version_list,
       std::vector<int64>* freq_list,
+      int64 emb_index,
       const EmbeddingConfig& emb_config,
       SsdRecordDescriptor<K>* ssd_rec_desc) {
     return storage_->
         GetSnapshotWithoutFetchPersistentEmb(
             key_list, value_list, version_list,
-            freq_list, emb_config, ssd_rec_desc);
+            freq_list, emb_index, emb_config, ssd_rec_desc);
   }
 
   void RestoreSsdHashmap(

--- a/tensorflow/core/kernels/kv_variable_ops.cc
+++ b/tensorflow/core/kernels/kv_variable_ops.cc
@@ -308,13 +308,11 @@ class InitializeKvVariableOp : public OpKernel {
                   context->device()->GetAllocator(AllocatorAttributes());
                   //context->get_allocator(AllocatorAttributes());
               auto embedding_config = EmbeddingConfig(
-                  emb_index_ + block_num_ * slot_index_,
                   emb_index_, block_num_, slot_num_,
-                  opname + "-primary", steps_to_live_,
-                  filter_freq_, max_freq_,
+                  steps_to_live_, filter_freq_, max_freq_,
                   l2_weight_threshold_, layout_,
                   max_element_size_, false_positive_probability_,
-                  counter_type_, default_value_dim_,
+                  counter_type_,
                   default_value_no_permission_,
                   record_freq_, record_version_);
               auto storage_manager =
@@ -324,41 +322,46 @@ class InitializeKvVariableOp : public OpKernel {
                       storage_type_, storage_path_, storage_size_, layout_,
                       embedding_config),
                     gpu_allocator);
-              *ptr = new EmbeddingVar<TKey, TValue>(handle_self.name(),
-                         storage_manager,
-                         embedding_config,
-                         gpu_allocator);
+              *ptr = new EmbeddingVar<TKey, TValue>(
+                  handle_self.name(),
+                  storage_manager,
+                  emb_index_ + block_num_ * slot_index_,
+                  embedding_config,
+                  gpu_allocator);
             return Status::OK();
             }));
       ev->Init(default_values, default_value_dim_);
     } else {
       EmbeddingVar<TKey, TValue>* primary_variable = nullptr;
+      int64 primary_emb_index(0);
+      auto embedding_config = EmbeddingConfig(
+          primary_emb_index, block_num_, slot_num_,
+          steps_to_live_, filter_freq_, max_freq_,
+          l2_weight_threshold_, layout_,
+          max_element_size_, false_positive_probability_,
+          counter_type_, 0, record_freq_, record_version_);
+
       OP_REQUIRES_OK(
        context,
        LookupOrCreateResource<EmbeddingVar<TKey, TValue>>(
            context, handle_primary, &primary_variable,
-           [this, default_values, opname,
+           [this, default_values, embedding_config,
+            primary_emb_index, opname,
             handle_primary, context](EmbeddingVar<TKey, TValue>** ptr) {
-             int64 primary_slot_index(0), primary_emb_index(0);
+             int64 primary_slot_index(0);
              Allocator* gpu_allocator = context->device()->GetAllocator(AllocatorAttributes());
              //Allocator* gpu_allocator = context->get_allocator(AllocatorAttributes());
-             auto embedding_config = EmbeddingConfig(
-                 primary_emb_index + block_num_ * primary_slot_index,
-                 primary_emb_index,
-                 block_num_, slot_num_, opname + "-primary",
-                 steps_to_live_, filter_freq_, max_freq_,
-                 l2_weight_threshold_, layout_,
-                 max_element_size_, false_positive_probability_,
-                 counter_type_, 0, record_freq_, record_version_);
              auto storage_manager =
                new embedding::StorageManager<TKey, TValue>(
                  handle_primary.name(), embedding::StorageConfig(storage_type_,
                      storage_path_, storage_size_, layout_, embedding_config),
                      gpu_allocator);
-             *ptr = new EmbeddingVar<TKey, TValue>(handle_primary.name(),
-                        storage_manager,
-                        embedding_config,
-                        gpu_allocator);
+             *ptr = new EmbeddingVar<TKey, TValue>(
+                 handle_primary.name(),
+                 storage_manager,
+                 primary_emb_index + block_num_ * primary_slot_index,
+                 embedding_config,
+                 gpu_allocator);
             // default_values is slot value, should not to initialize primary value
             return Status::OK();
            }));
@@ -367,20 +370,14 @@ class InitializeKvVariableOp : public OpKernel {
         context,
         LookupOrCreateResource<EmbeddingVar<TKey, TValue>>(
             context, handle_self, &ev,
-            [this, default_values, opname, primary_variable,
+            [this, default_values, opname,
+             primary_variable, embedding_config,
              handle_self, context](EmbeddingVar<TKey, TValue>** ptr) {
-              *ptr = new EmbeddingVar<TKey, TValue>(handle_self.name(),
+              *ptr = new EmbeddingVar<TKey, TValue>(
+                  handle_self.name(),
                   primary_variable->storage_manager(),
-                  EmbeddingConfig(emb_index_ + block_num_ * slot_index_,
-                                  emb_index_,
-                                  block_num_, slot_num_, opname,
-                                  steps_to_live_, filter_freq_,
-                                  max_freq_, l2_weight_threshold_,
-                                  layout_, max_element_size_,
-                                  false_positive_probability_,
-                                  counter_type_, default_value_dim_,
-                                  default_value_no_permission_,
-                                  record_freq_, record_version_),
+                  emb_index_ + block_num_ * slot_index_,
+                  embedding_config,
                   primary_variable->GetAllocator());
              return (*ptr)->Init(default_values, default_value_dim_);
             }));

--- a/tensorflow/core/kernels/kv_variable_save_restore_ops.cc
+++ b/tensorflow/core/kernels/kv_variable_save_restore_ops.cc
@@ -163,14 +163,13 @@ class KvResourceImportV2Op: public AsyncOpKernel {
              Allocator* allocator =
                 context->device()->GetAllocator(AllocatorAttributes());
              auto embedding_config = EmbeddingConfig(
-                 emb_index_ + block_num_ * slot_index_,
                  emb_index_,
-                 block_num_, slot_num_, opname + "-primary",
+                 block_num_, slot_num_,
                  steps_to_live_, filter_freq_,
                  max_freq_, l2_weight_threshold_,
                  layout_,  max_element_size_,
                  false_positive_probability_,
-                 counter_type_, default_value_dim_,
+                 counter_type_,
                  default_value_no_permission_,
                  record_freq_, record_version_);
               auto storage_manager =
@@ -180,6 +179,7 @@ class KvResourceImportV2Op: public AsyncOpKernel {
                     embedding_config));
               *ptr = new EmbeddingVar<TKey, TValue>(handle_self.name(),
                          storage_manager,
+                         emb_index_ + block_num_ * slot_index_,
                          embedding_config,
                          allocator);
              return Status::OK();
@@ -187,30 +187,32 @@ class KvResourceImportV2Op: public AsyncOpKernel {
       ev->Init(default_values, default_value_dim_);
     } else {
       EmbeddingVar<TKey, TValue>* primary_variable = nullptr;
-      OP_REQUIRES_OK(
-       context,
-       LookupOrCreateResource<EmbeddingVar<TKey, TValue>>(
-           context, handle_primary, &primary_variable,
-           [this, default_values, opname, context,
-            handle_primary](EmbeddingVar<TKey, TValue>** ptr) {
-             int64 primary_slot_index(0), primary_emb_index(0);
-             Allocator* allocator =
-                context->device()->GetAllocator(AllocatorAttributes());
-             auto embedding_config = EmbeddingConfig(
-                 primary_emb_index + block_num_ * primary_slot_index,
+      int64 primary_emb_index(0);
+      auto embedding_config = EmbeddingConfig(
                  primary_emb_index, block_num_, slot_num_,
-                 opname + "-primary", steps_to_live_, filter_freq_,
+                 steps_to_live_, filter_freq_,
                  max_freq_, l2_weight_threshold_,
                  layout_,  max_element_size_,
                  false_positive_probability_,
                  counter_type_, 0, record_freq_, record_version_);
+      OP_REQUIRES_OK(
+       context,
+       LookupOrCreateResource<EmbeddingVar<TKey, TValue>>(
+           context, handle_primary, &primary_variable,
+           [this, default_values, embedding_config,
+            primary_emb_index, opname, context,
+            handle_primary](EmbeddingVar<TKey, TValue>** ptr) {
+             int64 primary_slot_index(0);
+             Allocator* allocator =
+                context->device()->GetAllocator(AllocatorAttributes());
              auto storage_manager =
                new embedding::StorageManager<TKey, TValue>(
                  handle_primary.name(), embedding::StorageConfig(
                    storage_type_, storage_path_, storage_size_,
                    layout_, embedding_config));
              *ptr = new EmbeddingVar<TKey, TValue>(handle_primary.name(),
-                 storage_manager, embedding_config, allocator);
+                 storage_manager, primary_emb_index + block_num_ * primary_slot_index,
+                 embedding_config, allocator);
             // default_values is slot value, should not to initialize primary value
             return Status::OK();
            }));
@@ -219,21 +221,15 @@ class KvResourceImportV2Op: public AsyncOpKernel {
         context,
         LookupOrCreateResource<EmbeddingVar<TKey, TValue>>(
             context, handle_self, &ev,
-            [this, default_values, opname, primary_variable,
+            [this, default_values, embedding_config,
+             opname, primary_variable,
              handle_self, context](EmbeddingVar<TKey, TValue>** ptr) {
               Allocator* allocator =
                 context->device()->GetAllocator(AllocatorAttributes());
               *ptr = new EmbeddingVar<TKey, TValue>(handle_self.name(),
                   primary_variable->storage_manager(),
-                  EmbeddingConfig(emb_index_ + block_num_ * slot_index_,
-                    emb_index_, block_num_, slot_num_, opname,
-                    steps_to_live_, filter_freq_, max_freq_,
-                    l2_weight_threshold_, layout_, max_element_size_,
-                    false_positive_probability_,
-                    counter_type_, default_value_dim_,
-                    default_value_no_permission_,
-                    record_freq_, record_version_),
-                    allocator);
+                  emb_index_ + block_num_ * slot_index_,
+                  embedding_config, allocator);
              return (*ptr)->Init(default_values, default_value_dim_);
             }));
       core::ScopedUnref unref_me(primary_variable);


### PR DESCRIPTION
1. Remove emb_index, default_value_dim and name from EmbeddingConfig.
2. Multiple objects share the same EmbeddingConfig object.