### PR TITLE
[Runtime] Remove read limit of ReadBinaryProto.

### DIFF
--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -508,14 +508,7 @@ Status ReadBinaryProto(Env* env, const string& fname,
   TF_RETURN_IF_ERROR(env->NewRandomAccessFile(fname, &file));
   std::unique_ptr<FileStream> stream(new FileStream(file.get()));
 
-  // TODO(jiayq): the following coded stream is for debugging purposes to allow
-  // one to parse arbitrarily large messages for MessageLite. One most likely
-  // doesn't want to put protobufs larger than 64MB on Android, so we should
-  // eventually remove this and quit loud when a large protobuf is passed in.
   ::tensorflow::protobuf::io::CodedInputStream coded_stream(stream.get());
-  // Total bytes hard limit / warning limit are set to 1GB and 512MB
-  // respectively.
-  coded_stream.SetTotalBytesLimit(1024LL << 20, 512LL << 20);
 
   if (!proto->ParseFromCodedStream(&coded_stream) ||
       !coded_stream.ConsumedEntireMessage()) {


### PR DESCRIPTION
Signed-off-by: Secret.Sun <sunputonsteam@gmail.com>
 
Fix saved_model.pb more than 1073741824 bytes #979

Flow https://github.com/tensorflow/tensorflow/commit/dc3099c444d294b39cd79fe1d1a4bff59a0c6180
