### PR TITLE
[Tensorflow] Fix potential vulnerable cloned function

### DIFF
--- a/tensorflow/core/kernels/conv_grad_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_ops.cc
@@ -131,6 +131,10 @@ Status ConvBackpropComputeDimensionsV2(
   // dimensions of the filter Tensor.
   VLOG(2) << "input vs filter_in depth " << dims->in_depth << " "
           << filter_shape.dim_size(num_dims - 2);
+  if (filter_shape.dim_size(num_dims - 2) <= 0) {
+    return errors ::InvalidArgument(
+        label, ": filter depth must be strictly greated than zero");
+  }
   if (dims->in_depth % filter_shape.dim_size(num_dims - 2)) {
     return errors::InvalidArgument(
         label, ": input depth must be evenly divisible by filter depth");


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in a clone function ConvBackpropComputeDimensionsV2() in `tensorflow/lite/kernels/quantize_op.cc` sourced from [tensorflow/tensorflow](https://github.com/tensorflow/tensorflow). This issue, originally reported in [CVE-2021-29524](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2021-29524), was resolved in the repository via this commit https://github.com/tensorflow/tensorflow/commit/fca9874a9b42a2134f907d2fb46ab774a831404a.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Additionally, I suggest updating this `tensorflow` component to avoid unexpected vulnerabilities.

Please review at your convenience. Thank you!